### PR TITLE
DRAFT UPDATE to GitHub Marketplace Terms of Service

### DIFF
--- a/Policies/github-marketplace-terms-of-service.md
+++ b/Policies/github-marketplace-terms-of-service.md
@@ -1,12 +1,12 @@
 ---
-title: DRAFT - GitHub Marketplace Terms of Service
+title: GitHub Marketplace Terms of Service
 ---
 
 Welcome to GitHub Marketplace ("Marketplace")! We're happy you're here. Please read these Terms of Service ("Marketplace Terms") carefully before accessing or using GitHub Marketplace. GitHub Marketplace is a platform that allows you to purchase developer products (for free or for a charge) that can be used with your GitHub.com account ("Developer Products"). Although sold by GitHub, Inc. ("GitHub", "we", "us"), Developer Products may be developed and maintained by either GitHub or by third-party software providers, and may require you to agree to a separate terms of service. Your use and/or purchase of Developer Products is subject to these Marketplace Terms and to the applicable fees and may also be subject to additional terms as provided by the third party licensor of that Developer Product (the "Product Provider").
 
 By using Marketplace, you are agreeing to be bound by these Marketplace Terms.
 
-Effective Date:
+Effective Date: August 7, 2017
 
 ### A. GitHub.com's Terms of Service
 

--- a/Policies/github-marketplace-terms-of-service.md
+++ b/Policies/github-marketplace-terms-of-service.md
@@ -1,12 +1,12 @@
 ---
-title: GitHub Marketplace Terms of Service
+title: DRAFT - GitHub Marketplace Terms of Service
 ---
 
 Welcome to GitHub Marketplace ("Marketplace")! We're happy you're here. Please read these Terms of Service ("Marketplace Terms") carefully before accessing or using GitHub Marketplace. GitHub Marketplace is a platform that allows you to purchase developer products (for free or for a charge) that can be used with your GitHub.com account ("Developer Products"). Although sold by GitHub, Inc. ("GitHub", "we", "us"), Developer Products may be developed and maintained by either GitHub or by third-party software providers, and may require you to agree to a separate terms of service. Your use and/or purchase of Developer Products is subject to these Marketplace Terms and to the applicable fees and may also be subject to additional terms as provided by the third party licensor of that Developer Product (the "Product Provider").
 
 By using Marketplace, you are agreeing to be bound by these Marketplace Terms.
 
-Effective Date: May 22, 2017
+Effective Date:
 
 ### A. GitHub.com's Terms of Service
 
@@ -28,7 +28,7 @@ We are not a party to the agreement between you and the Product Provider with re
 
 ### D. Payment, Billing Schedule, and Cancellation
 
-All payments for Developer Products will go through GitHub. The terms of your payment and fees will be governed by [Section K. Payment](/articles/github-terms-of-service/#k-payment), or the analogous section of your applicable GitHub Terms. By using the Marketplace, you agree to pay GitHub any charge incurred in connection with your purchase of the Developer Product. Each purchase is an electronic contract between you and GitHub, and you and the Product Provider. You are responsible for providing us with a valid means of payment for purchases of Developer Products. If you are only purchasing free Developer Products, you are not required to provide payment information.
+All payments for Developer Products will go through GitHub. The terms of your payment and fees will be governed by [Section L. Payment](/articles/github-terms-of-service/#l-payment), or the analogous section of your applicable GitHub Terms. By using the Marketplace, you agree to pay GitHub any charge incurred in connection with your purchase of the Developer Product. Each purchase is an electronic contract between you and GitHub, and you and the Product Provider. You are responsible for providing us with a valid means of payment for purchases of Developer Products. If you are only purchasing free Developer Products, you are not required to provide payment information.
 
 **Billing Schedule; No Refunds.** Your payment schedule is determined by the payment schedule you chose when you created your GitHub account (e.g. free, monthly, annual). For monthly or yearly payment plans, Marketplace purchases are billed in advance on a monthly or yearly basis respectively and are non-refundable. There will be no refunds or credits for partial months of service, downgrade refunds, or refunds for months unused; however, the service will remain active for the length of the paid billing period. If you would like to cancel the Developer Product services, you can do so by going into your Settings in the global navigation bar at the top of the screen.
 


### PR DESCRIPTION
This is a Draft Update to the GitHub Marketplace Terms of Service. These changes will not be effective until July 21, 2017. This pull request contains only immaterial changes.

This pull request is closed because we're not looking for feedback right now on these terms. Along with the other updates, this pull request will be reopened and merged on ~July 21, 2017~ August 7, 2017 [EDITED].