### PR TITLE
Make effective against all U.S. government employees, not just agencies

### DIFF
--- a/Policies/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users.md
+++ b/Policies/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users.md
@@ -7,7 +7,7 @@ redirect_from:
 
 {{#tip}}
 
-This Amendment to GitHub's [Terms of Service](/articles/github-terms-of-service) applies only to users that are using GitHub on behalf of a United States federal government. If you are not using GItHub on behalf of a U.S. federal government agency, the standard [GitHub Terms of Service](/articles/github-terms-of-service) applies to you.
+This Amendment to GitHub's [Terms of Service](/articles/github-terms-of-service) applies only to users that are using GitHub on behalf of the United States federal government. If you are not using GItHub on behalf of a U.S. federal government agency, the standard [GitHub Terms of Service](/articles/github-terms-of-service) applies to you.
 
 {{/tip}}
 

--- a/Policies/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users.md
+++ b/Policies/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users.md
@@ -7,11 +7,11 @@ redirect_from:
 
 {{#tip}}
 
-This Amendment to GitHub's [Terms of Service](/articles/github-terms-of-service) applies only to users that are using GitHub on behalf of a United States federal government agency. If you are not using GItHub on behalf of a U.S. federal government agency, the standard [GitHub Terms of Service](/articles/github-terms-of-service) applies to you.
+This Amendment to GitHub's [Terms of Service](/articles/github-terms-of-service) applies only to users that are using GitHub on behalf of a United States federal government. If you are not using GItHub on behalf of a U.S. federal government agency, the standard [GitHub Terms of Service](/articles/github-terms-of-service) applies to you.
 
 {{/tip}}
 
-This Amendment is an agreement between GitHub, Inc. ("GitHub" or "Company") and U.S. federal government users of the GitHub.com web site (the “Service”) and applies solely to any U.S. Government agency users who use or access the Service on behalf of a U.S. federal government agency (the "Agency").
+This Amendment is an agreement between GitHub, Inc. ("GitHub" or "Company") and U.S. federal government users of the GitHub.com web site (the “Service”) and applies solely to any U.S. Government agency users who use or access the Service on behalf of a U.S. federal government agency or other component of the U.S. federal government (the "Agency").
 
 You, as a United States government entity, are required, when entering into agreements with other parties, to follow applicable federal laws and regulations, including those related to ethics; privacy and security; accessibility; records retention; limitations on indemnification; fiscal law constraints; advertising and endorsements; freedom of information; and governing law and dispute resolution forum.
 


### PR DESCRIPTION
The language would not have included federal employees other than those of the executive branch due to use of the word "agency."  That is, an assistant to a member of Congress or the court clerk of a federal judge do not work for an "agency," but do work for the federal government.  The changes expand the definition of who is covered.

Jonathan Corbett
jon@professional-troublemaker.com