### PR TITLE
Correct spelling of GItHub to GitHub

### DIFF
--- a/Policies/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users.md
+++ b/Policies/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users.md
@@ -7,7 +7,7 @@ redirect_from:
 
 {{#tip}}
 
-This Amendment to GitHub's [Terms of Service](/articles/github-terms-of-service) applies only to users that are using GitHub on behalf of a United States federal government agency. If you are not using GItHub on behalf of a U.S. federal government agency, the standard [GitHub Terms of Service](/articles/github-terms-of-service) applies to you.
+This Amendment to GitHub's [Terms of Service](/articles/github-terms-of-service) applies only to users that are using GitHub on behalf of a United States federal government agency. If you are not using GitHub on behalf of a U.S. federal government agency, the standard [GitHub Terms of Service](/articles/github-terms-of-service) applies to you.
 
 {{/tip}}
 


### PR DESCRIPTION
An exceedingly minor edit.