### PR TITLE
Privacy statement spring 2018

### DIFF
--- a/Policies/github-privacy-statement.md
+++ b/Policies/github-privacy-statement.md
@@ -8,14 +8,34 @@ redirect_from:
  - /articles/github-privacy-policy/
 ---
 
-Effective date: **October 11, 2017**
+Effective date: **May 25, 2018**
 
 Thanks for entrusting GitHub with your source code, your projects, and your personal information. Holding onto your private information is a serious responsibility, and we want you to know how we're handling it.
 
 ### The short version
-We collect your information only with your consent; we only collect the minimum amount of personal information that is necessary to fulfill the purpose of your interaction with us; we don't sell it to third parties; and we only use it as this Privacy Statement describes. If you're visiting us from the EU: we comply with the [Privacy Shield framework](https://www.privacyshield.gov/participant?id=a2zt000000001K2AAI).
+
+We only collect the information you choose to give us, and we process it with your consent, or on another legal basis; we only require the minimum amount of personal information that is necessary to fulfill the purpose of your interaction with us; we don't sell it to third parties; and we only use it as this Privacy Statement describes. If you're visiting us from the EU, please see our [global privacy practices](#githubs-global-privacy-practices): we comply with the [Privacy Shield framework](https://www.privacyshield.gov/participant?id=a2zt000000001K2AAI) and we are compliant with the General Data Protection Regulation (GDPR). No matter where you are, where you live, or what your citizenship is, we provide the same standard of privacy protection to all our users around the world, regardless of their country of origin or location.
 
 Of course, the short version doesn't tell you everything, so please read on for more details!
+
+### Summary
+
+| Section | What can you find there? |
+|---|---|
+| [What information GitHub collects and why](#what-information-github-collects-and-why) | GitHub collects basic information from visitors to our website, and some personal information from our users. We only require the minimum amount of personal information necessary from you. This section gives details. |
+| [What information GitHub does not collect](#what-information-github-does-not-collect) | We don’t collect information from children under 13, and we don’t collect sensitive data. |
+| [How we share the information we collect](#how-we-share-the-information-we-collect) | We share information to provide the service to you, to comply with your requests, or with our vendors. We do not host advertising on GitHub and we do not sell your personal information. You can see a list of the vendors that access your personal information. |
+| [How you can access and control the information we collect](#how-you-can-access-and-control-the-information-we-collect) | We provide ways for you to access, alter, or delete your profile information. You can also contact Support for more help. | 
+| [Our use of cookies and tracking](#our-use-of-cookies-and-tracking) | We use cookies for the overall functionality of our website, and we use a small number of tracking and analytics services on a few parts of our site. We offer a page that makes this very transparent. Please see this section for more information. |
+| [How GitHub secures your information](#how-github-secures-your-information) | We take all measures reasonably necessary to protect the confidentiality, integrity, and availability of your personal information on GitHub and to protect the resiliance of our servers as they host your information. | 
+| [GitHub's global privacy practices](#githubs-global-privacy-practices) | GitHub complies with both the EU-US Privacy Shield Framework and the General Data Protection Regulation. Please see this section for more specific information. | 
+| [How we respond to compelled disclosure](#how-we-respond-to-compelled-disclosure) | We may share your information in response to a warrant, subpoena, or other court action, or if disclosure is necessary to protect our rights or the rights of the public at large. We strive for transparency, and will notify you when possible. | 
+| [How we communicate with you](#how-we-communicate-with-you) | We communicate with you by email. You can control the way we contact you in your account settings. | 
+| [Resolving complaints](#resolving-complaints) | In the unlikely event that we are unable to resolve a privacy concern quickly and thoroughly, we provide a path of dispute resolution through external arbiters. | 
+| [Changes to our Privacy Statement](#changes-to-our-privacy-statement) | We will notify you of material changes to this Privacy Statement 30 days in advance of any such changes becoming effective. You may also track changes in our Site Policy repository. | 
+| [Contacting GitHub](#contacting-github) | Please feel free to contact us if you have questions about our Privacy Statement. | 
+
+### GitHub Privacy Statement
 
 ### What information GitHub collects and why
 
@@ -25,119 +45,150 @@ If you're **just browsing the website**, we collect the same basic information t
 
 The information we collect about all visitors to our website includes the visitor’s browser type, language preference, referring site, additional websites requested, and the date and time of each visitor request. We also collect potentially personally-identifying information like Internet Protocol (IP) addresses.
 
-##### Why do we collect this?
+##### Why we collect this
 
 We collect this information to better understand how our website visitors use GitHub, and to monitor and protect the security of the website.
 
 #### Information from users with accounts
 
-If you **create an account**, we require some basic information at the time of account creation. You will create your own user name and password, and we will ask you for a valid email account. You also have the option to give us more information if you want to, and this may include "User Personal Information."
+If you **create an account**, we require some basic information at the time of account creation. You will create your own user name and password, and we will ask you for a valid email address. You also have the option to give us more information if you want to, and this may include "User Personal Information."
 
-"User Personal Information" is any information about one of our users which could, alone or together with other information, personally identify him or her. Information such as a user name and password, an email address, a real name, and a photograph are examples of “User Personal Information.”
+"User Personal Information" is any information about one of our users which could, alone or together with other information, personally identify him or her. Information such as a user name and password, an email address, a real name, and a photograph are examples of “User Personal Information.” User Personal Information includes Personal Data as defined in the General Data Protection Regulation.
 
 User Personal Information does not include aggregated, non-personally identifying information. We may use aggregated, non-personally identifying information to operate, improve, and optimize our website and service.
 
-##### Why do we collect this?
+##### Why we collect this
 
-- We need your User Personal Information to create your account, and to provide the services you request.
+- We need your User Personal Information to create your account, and to provide the services you request, including to provide the GitHub service, the Marketplace service, or to respond to support requests.
 - We use your User Personal Information, specifically your user name, to identify you on GitHub.
 - We use it to fill out your profile and share that profile with other users if you ask us to.
-- We will use your email address to communicate with you, if you've said that's okay, **and only for the reasons you’ve said that’s okay**. Please see our section on [email communication](#how-we-communicate-with-you) for more information.
+- We will use your email address to communicate with you, if you've said that's okay, **and only for the reasons you’ve said that’s okay**. Please see our section on [email communication](#how-we-communicate-with-you) for more information. 
+- We use User Personal Information to make recommendations for you, such as to suggest projects you may want to follow or contribute to. For example, when you fill out your biography in your Account Settings, we learn from it — as well as from your public behavior on GitHub — to determine your coding interests. These recommendations are automated decisions, but they have no legal impact on your rights.
+- We use your User Personal Information for internal purposes, such as to maintain logs for security reasons, for training purposes, and for legal documentation.
 - We limit our use of your User Personal Information to the purposes listed in this Privacy Statement. If we need to use your User Personal Information for other purposes, we will ask your permission first. You can always see what information we have, how we're using it, and what permissions you have given us in your [user profile](https://github.com/settings/admin).
+
+##### Our legal basis for processing information
+
+Under certain international laws (including GDPR), GitHub is required to notify you about the legal basis on which we process User Personal Information. GitHub processes User Personal Information on the following legal bases:
+
+- When you create a GitHub account, you provide your user name and an email address. We require those data elements for you to enter into the Terms of Service agreement with us, and we process those elements on the basis of performing that contract. We also process your user name and email address on other bases. If you have a GitHub Hosted, GitHub Enterprise, or other paid account with us, there will be other data elements we must collect and process on the basis of performing that contract. GitHub does not collect or process a credit card number, but our third-party payment processor does.
+- When you fill out the information in your [user profile](https://github.com/settings/profile), you have the option to provide User Personal Information such as your full name, an avatar which may include a photograph, your biography, your location, your company, and a URL to a third party website. You have the option of setting a publicly visible email address here. We process this information on the basis of consent. All of this information is entirely optional, and you have the ability to access, modify, and delete it at any time (while you are not able to delete your email address entirely, you can set it private). 
+- Generally, the remainder of the processing of personal information we perform is necessary for the purposes of our legitimate interests. For example, for security purposes, we must keep logs of IP addresses that access GitHub, and in order to respond to legal process, we are required to keep records of users who have sent and received DMCA takedown notices.
+- If you would like to request erasure of data we process on the basis of consent or object to our processing of personal information, please use our {{ site.data.variables.contact.contact_privacy }}. 
 
 ### What information GitHub does not collect
 
-We do not intentionally collect **sensitive personal information**, such as social security numbers, genetic data, health information, or religious information. Although GitHub does not request or intentionally collect any sensitive personal information, we realize that you might store this kind of information in your account, such as in a repository. If you store any sensitive personal information on our servers, you are consenting to our storage of that information on our servers, which are in the United States.
+We do not intentionally collect **sensitive personal information**, such as social security numbers, genetic data, health information, or religious information. Although GitHub does not request or intentionally collect any sensitive personal information, we realize that you might store this kind of information in your account, such as in a repository. If you store any sensitive personal information on our servers, you are responsible for complying with any regulatory controls regarding that data.
 
-We do not intentionally collect information that is **stored in your repositories** or other free-form content inputs. Information in your repositories belongs to you, and you are responsible for it, as well as for making sure that your content complies with our [Terms of Service](/articles/github-terms-of-service/). GitHub employees [do not access private repositories unless required to](/articles/github-security/#employee-access) for security or maintenance, or for support reasons, with the consent of the repository owner.
+If you're a **child under the age of 13**, you may not have an account on GitHub. GitHub does not knowingly collect information from or direct any of our content specifically to children under 13. If we learn or have reason to suspect that you are a user who is under the age of 13, we will unfortunately have to close your account. We don't want to discourage you from learning to code, but those are the rules. Please see our [Terms of Service](/articles/github-terms-of-service/) for information about account termination. Other countries may have different minimum age limits, and if you are below the minimum age for providing consent for data collection in your country, you may not use GitHub without obtaining your parents' or legal guardians' consent. 
 
-If your repository is public, anyone (including us) may view its contents. If you have included private or sensitive information in your public repository, such as email addresses, that information may be indexed by search engines or used by third parties. In addition, while we do not generally search for content in your repositories, we may scan our servers for certain tokens or security signatures.
+We do not intentionally collect User Personal Information that is **stored in your repositories** or other free-form content inputs. Information in your repositories belongs to you, and you are responsible for it, as well as for making sure that your content complies with our [Terms of Service](/articles/github-terms-of-service/). Any personal information within a user's repository is the responsibility of the repository owner. 
 
-If you're a **child under the age of 13**, you may not have an account on GitHub. GitHub does not knowingly collect information from or direct any of our content specifically to children under 13. If we learn or have reason to suspect that you are a user who is under the age of 13, we will unfortunately have to close your account. We don't want to discourage you from learning to code, but those are the rules. Please see our [Terms of Service](/articles/github-terms-of-service/) for information about account termination.
+#### Repository contents
+
+GitHub employees [do not access private repositories unless required to](/articles/github-terms-of-service/#e-private-repositories) for security reasons, to assist the repository owner with a support matter, or to maintain the integrity of the service. Our Terms of Service provides [more details](/articles/github-terms-of-service/#e-private-repositories).
+
+If your repository is public, anyone (including us and unaffiliated third parties) may view its contents. If you have included private or sensitive information in your public repository, such as email addresses or passwords, that information may be indexed by search engines or used by third parties. In addition, while we do not generally search for content in your repositories, we may scan our servers for certain tokens or security signatures, or for known active malware.
+
+Please see more about [User Personal Information in public repositories](#public-information-on-github).
 
 ### How we share the information we collect
 
-We **do not** share, sell, rent, or trade User Personal Information with third parties for their commercial purposes.
+We do share User Personal Information with your permission, so we can perform services you have requested or communicate on your behalf. For example, if you purchase an integration or other Developer Product from our Marketplace, we will share your account name to allow the integrator to provide you services. Additionally, you may indicate, through your actions on GitHub, that you are willing to share your User Personal Information. For example, if you join an organization, the owner of the organization will have the ability to view your activity in the organization's access log. We will respect your choices.
 
-We do not disclose User Personal Information outside GitHub, except in the situations listed in this section or in the section below on [Compelled Disclosure](#how-we-respond-to-compelled-disclosure).
+We **do not** share, sell, rent, or trade User Personal Information with third parties for their commercial purposes, expect where you have specifically told us to (such as by buying an integration from Marketplace).
+
+We **do not** host advertising on GitHub. We may occasionally embed content from third party sites, such as YouTube, and that content may include ads. While we try to minimize the amount of ads our embedded content contains, we can't always control what third parties show. Any advertisements on individual GitHub Pages or in GitHub repositories are not sponsored by, or tracked by, GitHub. 
+
+We **do not** disclose User Personal Information outside GitHub, except in the situations listed in this section or in the section below on [Compelled Disclosure](#how-we-respond-to-compelled-disclosure).
 
 We **do** share certain aggregated, non-personally identifying information with others about how our users, collectively, use GitHub, or how our users respond to our other offerings, such as our conferences or events. For example, we may [compile statistics on the usage of open source licenses across GitHub](https://github.com/blog/1964-open-source-license-usage-on-github-com). However, we do not sell this information to advertisers or marketers.
 
-We do not host advertising on GitHub. We may occasionally embed content from third party sites, such as YouTube, and that content may include ads. While we try to minimize the amount of ads our embedded content contains, we can't always control what third parties show.
+We **do** share User Personal Information with a limited number of third party vendors who process it on our behalf to provide or improve our service, and who have agreed to privacy restrictions similar to our own Privacy Statement by signing data protection agreements. Our vendors perform services such as payment processing, customer support ticketing, network data transmission, and other similar services. When we transfer your data to our vendors under [Privacy Shield](/articles/github-privacy-statement/#githubs-global-privacy-practices), we remain responsible for it. While GitHub processes all User Personal Information in the United States, our third party vendors may process data outside of the United States or the European Union. If you would like to know who our third party vendors are, please see our page on [Subprocessors](/articles/github-subprocessors-and-cookies/).
 
-We may share User Personal Information with your permission, so we can perform services you have requested.
-
-We may share User Personal Information with a limited number of third-party vendors who process it on our behalf to provide or improve our service, and who have agreed to privacy restrictions similar to our own Privacy Statement. Our vendors perform services such as payment processing, customer support ticketing, network data transmission, and other similar services. When we transfer your data to our vendors under [Privacy Shield](/articles/github-privacy-statement/#githubs-global-privacy-practices), we remain responsible for it.
+We do share aggregated, non-personally identifying information with third parties. For example, we share the number of stars on a repository, or in the event of a security incident, we may share the number of times a particular file was accessed. 
 
 We may share User Personal Information if we are involved in a merger, sale, or acquisition. If any such change of ownership happens, we will ensure that it is under terms that preserve the confidentiality of User Personal Information, and we will notify you on our website or by email before any transfer of your User Personal Information. The organization receiving any User Personal Information will have to honor any promises we have made in our Privacy Statement or in our Terms of Service.
 
-#### Public Information on GitHub
+#### Public information on GitHub
 
-Much of GitHub is public-facing. If your content is public-facing, third parties may access and use it in compliance with our Terms of Service. We do not sell that content; it is yours. However, we do allow third parties, such as research organizations or archives, to compile public-facing GitHub information.
+Much of GitHub is public-facing. If your content is public-facing, third parties may access and use it in compliance with our Terms of Service, such as by viewing your profile or repositories or pulling data via our API. We do not sell that content; it is yours. However, we do allow third parties, such as research organizations or archives, to compile public-facing GitHub information. Other third parties, such as data brokers, have been known to scrape GitHub and compile data as well. 
 
-Your Personal Information, associated with your content, may be gathered by third parties in these compilations of GitHub data. If you do not want your Personal Information to appear in third parties’ compilations of GitHub data, please do not make your Personal Information publicly available and be sure to [configure your email address to be private in your user profile](https://github.com/settings/emails).
+Your Personal Information, associated with your content, could be gathered by third parties in these compilations of GitHub data. If you do not want your Personal Information to appear in third parties’ compilations of GitHub data, please do not make your Personal Information publicly available and be sure to [configure your email address to be private in your user profile](https://github.com/settings/emails). We set current users' email address private by default, but legacy GitHub users may need to update their settings.
 
-If you would like to compile GitHub data, you may only use any public-facing Personal Information you gather for the purpose for which our user has authorized it. For example, where a GitHub user has made an email address public-facing for the purpose of identification and attribution, do not use that email address for commercial advertising. We expect you to reasonably secure any Personal Information you have gathered from GitHub, and to respond promptly to complaints, removal requests, and "do not contact" requests from GitHub or GitHub users.
+If you would like to compile GitHub data, you must comply with our Terms of Service regarding [scraping](/articles/github-terms-of-service/#5-scraping) and [privacy](/articles/github-terms-of-service/#6-privacy), and you may only use any public-facing Personal Information you gather for the purpose for which our user has authorized it. For example, where a GitHub user has made an email address public-facing for the purpose of identification and attribution, do not use that email address for commercial advertising. We expect you to reasonably secure any Personal Information you have gathered from GitHub, and to respond promptly to complaints, removal requests, and "do not contact" requests from GitHub or GitHub users.
 
 Similarly, projects on GitHub may include publicly available Personal Information collected as part of the collaborative process. In the event that a GitHub project contains publicly available Personal Information that does not belong to GitHub users, we will only use that Personal Information for the limited purpose for which it was collected, and we will secure that Personal Information as we would secure any User Personal Information. If you have a complaint about any Personal Information on GitHub, please see our section on [resolving complaints](#resolving-complaints).
+
+#### Third party applications
+
+You have the option of enabling or adding third party applications, known as "Developer Products," to your account. These Developer Products are not necessary for your use of GitHub. We will share your User Personal Information to third parties when you ask us to, such as by purchasing a Developer Product from the Marketplace; however, you are responsible for your use of the third party Developer Product and for the amount of User Personal Information you choose to share with it. You can check our [API documentation](https://developer.github.com/v3/users/) to see what information is provided when you authenticate into a Developer Product using your GitHub profile.
+
+#### GitHub applications
+
+You also have the option of adding applications from GitHub, such as our Desktop app, our Mobile app, or other account features, to your account. These applications each have their own terms and may collect different kinds of User Personal Information; however, all GitHub applications are subject to this Privacy Statement, and we will always collect the minimum amount of User Personal Information necessary, and use it only for the purpose for which you have given it to us.
+
+### How you can access and control the information we collect
+
+If you're already a GitHub user, you may access, update, alter, or delete your basic user profile information by [editing your user profile](https://github.com/settings/profile) or contacting {{ site.data.variables.contact.contact_support }}. You can control the information we collect about you by limiting what information is in your profile, by updating out of date information, or by contacting {{ site.data.variables.contact.contact_support }}.  
+
+#### Data retention and deletion
+
+Generally, GitHub will retain User Personal Information for as long as your account is active or as needed to provide you services.
+
+We may retain certain User Personal Information indefinitely, unless you delete it or request its deletion. For example, we don’t automatically delete inactive user accounts, so unless you choose to delete your account, we will retain your account information indefinitely.
+
+If you would like to cancel your account or delete your User Personal Information, you may do so in your [user profile](https://github.com/settings/admin). We will retain and use your information as necessary to comply with our legal obligations, resolve disputes, and enforce our agreements, but barring legal requirements, we will delete your full profile (within reason) within 90 days. You may contact {{ site.data.variables.contact.contact_support }} to request the erasure of the data we process on the basis of consent within 30 days.
 
 ### Our use of cookies and tracking
 
 #### Cookies
 
-GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, and provide information for future development of GitHub.
+GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, and provide information for future development of GitHub. We also use cookies to identify a device, for security reasons. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept cookies, you will not be able to log in or use GitHub’s services.
 
-A cookie is a small piece of text that our web server stores on your computer or mobile device, which your browser sends to us when you return to our site. Cookies do not necessarily identify you if you are merely visiting GitHub; however, a cookie may store a unique identifier for each logged in user. The cookies GitHub sets are essential for the operation of the website, or are used for performance or functionality. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept cookies, you will not be able to log in or use GitHub’s services.
+We provide a web page on [cookies and tracking](/articles/github-subprocessors-and-cookies/) that describes the cookies we set, the needs we have for those cookies, and the types of cookies they are (temporary or permanent). It also lists our third party analytics and service providers and details exactly which parts of our website we permit them to track.
 
-#### Google Analytics
+#### Tracking and analytics
 
-We use Google Analytics as a third party tracking service, but we don’t use it to track you individually or collect your User Personal Information. We use Google Analytics to collect information about how our website performs and how our users, in general, navigate through and use GitHub. This helps us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance.
+We use a number of third party analytics and service providers to help us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. We only use these third party analytics providers on certain areas of our website, and all of them have signed data protection agreements with us that limit the type of personal information they can collect and the purpose for which they can process the information. In addition, we use our own internal analytics software to provide features and improve our content and performance.
 
-Google Analytics gathers certain simple, non-personally identifying information over time, such as your IP address, browser type, internet service provider, referring and exit pages, time stamp, and similar data about your use of GitHub. We do not link this information to any of your personal information such as your user name.
-
-GitHub will not, nor will we allow any third party to, use the Google Analytics tool to track our users individually; collect any User Personal Information other than IP address; or correlate your IP address with your identity. Google provides further information about its own privacy practices and offers a [browser add-on to opt out of Google Analytics tracking] (https://tools.google.com/dlpage/gaoptout).
-
-Certain pages on our site may set other third party cookies. For example, we may embed content, such as videos, from another site that sets a cookie. While we try to minimize these third party cookies, we can’t always control what cookies this third party content sets.
-
-#### Tracking
-
-"[Do Not Track](http://donottrack.us/)" is a privacy preference you can set in your browser if you do not want online services to collect and share certain kinds of information about your online activity from third party tracking services. We do not track your online browsing activity on other online services over time and we do not permit third-party services to track your activity on our site beyond our basic Google Analytics tracking, which you may opt out of [here]( https://tools.google.com/dlpage/gaoptout). Because we do not share this kind of data with third party services or permit this kind of third party data collection on GitHub for any of our users, and we do not track our users on third-party websites ourselves, we do not need to respond differently to an individual browser's Do Not Track setting.
-
-If you are interested in turning on your browser’s privacy and Do Not Track settings, the [Do Not Track](http://donottrack.us/) website has browser-specific instructions.
-
-Please see our section on [email communication](#how-we-communicate-with-you) to learn about our use of pixel tags in marketing emails.
+We do not currently respond to your browser's Do Not Track signal, and we do not permit third parties other than our analytics and service providers to track GitHub users' activity over time on GitHub. We do not track your online browsing activity on other online services over time. 
 
 ### How GitHub secures your information
 
-GitHub takes all measures reasonably necessary to protect User Personal Information from unauthorized access, alteration, or destruction; maintain data accuracy; and help ensure the appropriate use of User Personal Information. We follow generally accepted industry standards to protect the personal information submitted to us, both during transmission and once we receive it.
+GitHub takes all measures reasonably necessary to protect User Personal Information from unauthorized access, alteration, or destruction; maintain data accuracy; and help ensure the appropriate use of User Personal Information. 
+
+GitHub enforces a written security information program. Our program: 
+
+- aligns with industry recognized frameworks;  
+- includes security safeguards reasonably designed to protect the confidentiality, integrity, availability, and resilience of our users' data; 
+- is appropriate to the nature, size, and complexity of GitHub’s business operations; 
+- includes incident response and data breach notification processes; and 
+- complies with applicable information security related laws and regulations in the geographic regions where GitHub does business. 
+
+In the event of a data breach that affects your User Personal Information, we will act promptly to mitigate the impact of a breach and notify any affected users. 
+
+Transmission of data on GitHub is encrypted using SSH, HTTPS, and SSL/TLS. While our data is not encrypted at rest, we manage our own cages and racks at top-tier data centers with excellent physical and network security, and when data is stored with a third party storage provider, it is encrypted.
 
 No method of transmission, or method of electronic storage, is 100% secure. Therefore, we cannot guarantee its absolute security. For more information, see our [security disclosures](/articles/github-security/).
 
 ### GitHub's global privacy practices
-**Information that we collect will be stored and processed in the United States** in accordance with this Privacy Statement. However, we understand that we have users from different countries and regions with different privacy expectations, and we try to meet those needs.
 
-We provide the same standard of privacy protection to all our users around the world, regardless of their country of origin or location, and we are proud of the levels of notice, choice, accountability, security, data integrity, access, and recourse we provide. We have appointed a Privacy Counsel and we work hard to comply with the applicable data privacy laws wherever we do business. Additionally, we require that if our vendors or affiliates have access to User Personal Information, they must comply with our privacy policies and with applicable data privacy laws, including signing data transfer agreements such as Standard Contractual Clause agreements.
+**We store and process the information that we collect in the United States** in accordance with this Privacy Statement (our subprocessors may store and process data outside the United States). However, we understand that we have users from different countries and regions with different privacy expectations, and we try to meet those needs even when the United States does not have the same privacy framework as other countries'.
+
+We provide the same standard of privacy protection — as described in this Privacy Statement — to all our users around the world, regardless of their country of origin or location, and we are proud of the levels of notice, choice, accountability, security, data integrity, access, and recourse we provide. We have appointed a Privacy Counsel and we work hard to comply with the applicable data privacy laws wherever we do business, and we also expect to appoint a Data Protection Officer to oversee our compliance efforts. Additionally, if our vendors or affiliates have access to User Personal Information, they must sign agreements that require them to comply with our privacy policies and with applicable data privacy laws.
 
 In particular:
--	GitHub provides clear methods of unambiguous, informed consent at the time of data collection, when we do collect your personal data.
--	We collect only the minimum amount of personal data necessary, unless you choose to provide more. We encourage you to only give us the amount of data you are comfortable sharing.
--	We offer you simple methods of accessing, correcting, or deleting the data we have collected.
+-	GitHub provides clear methods of unambiguous, informed consent at the time of data collection, when we do collect your personal data using consent as a basis. 
+-	We collect only the minimum amount of personal data necessary for our purposes, unless you choose to provide more. We encourage you to only give us the amount of data you are comfortable sharing. 
+-	We offer you simple methods of accessing, correcting, or deleting the User Personal Information we have collected.
 -	We provide our users notice, choice, accountability, security, and access, and we limit the purpose for processing. We also provide our users a method of recourse and enforcement. These are the Privacy Shield Principles, but they are also just good practices.
--	GitHub adheres to the [Privacy Shield Framework](https://www.privacyshield.gov/). You may view our entry in the [Privacy Shield List](https://www.privacyshield.gov/participant?id=a2zt000000001K2AAI). In addition to providing our users methods of unambiguous, informed consent and control over their data, we participate in and comply with the Privacy Shield framework, and we are committed to subject any Personal Information we receive from the EU and EEA to the Privacy Shield Principles. In addition, we continue to participate in the Safe Harbor Framework for Swiss data transfers to the US. Please read more about [GitHub's Privacy Shield and Safe Harbor commitments](/articles/global-privacy-practices/).
 
-### Resolving Complaints
+#### Cross-border data transfers
 
-If you have concerns about the way GitHub is handling your User Personal Information, please let us know immediately. We want to help. You may contact us by filling out the {{ site.data.variables.contact.contact_privacy }}. You may also email us directly at privacy@github.com with the subject line "Privacy Shield Concerns." We will respond within 45 days at the latest.
+For cross-border data transfers from the European Union (EU) and the European Economic Area (EEA), GitHub adheres to the [Privacy Shield Framework](https://www.privacyshield.gov/). You may view our entry in the [Privacy Shield List](https://www.privacyshield.gov/participant?id=a2zt000000001K2AAI). 
 
-#### Dispute Resolution Process
-
-In the unlikely event that a dispute arises between you and GitHub regarding our handling of your User Personal Information, we will do our best to resolve it. If we cannot, we have selected JAMS, an independent dispute resolution provider, to handle unresolved Privacy Shield complaints. If we are unable to resolve your concerns after a good faith effort to address them, you may [contact JAMS and submit a Privacy Shield claim](https://www.jamsadr.com/file-an-eu-us-privacy-shield-or-safe-harbor-claim). JAMS is a US-based private alternate dispute resolution provider, and we have contracted with JAMS to provide an independent recourse mechanism for any of our users for privacy concerns **at no cost to you.** You do not need to appear in court; you may conduct this dispute resolution process via telephone or video conference. If you are not based in the EU or EEA, but you would still like to use the JAMS arbitration process to resolve your dispute, please let us know and we will provide access to you.
-
-#### Independent Arbitration
-
-Under certain limited circumstances, European Union individuals may invoke binding Privacy Shield arbitration as a last resort if all other forms of dispute resolution have been unsuccessful. To learn more about this method of resolution and its availability to you, please read more about [Privacy Shield](https://www.privacyshield.gov/article?id=ANNEX-I-introduction).
-
-We are subject to the jurisdiction of the Federal Trade Commission.
+In addition to providing our users methods of unambiguous, informed consent and control over their data, we participate in and comply with the Privacy Shield framework, and we are committed to subject any Personal Information we receive from the EU and EEA to the Privacy Shield Principles. In addition, we continue to participate in the Safe Harbor Framework for Swiss data transfers to the US. Please read more about [GitHub's international privacy commitments](/articles/global-privacy-practices/).
 
 ### How we respond to compelled disclosure
 GitHub may disclose personally-identifying information or other information we collect about you to law enforcement in response to a valid subpoena, court order, warrant, or similar government order, or when we believe in good faith that disclosure is reasonably necessary to protect our property or rights, or those of third parties or the public at large.
@@ -146,29 +197,34 @@ In complying with court orders and similar legal processes, GitHub strives for t
 
 For more information, see our [Guidelines for Legal Requests of User Data](/articles/guidelines-for-legal-requests-of-user-data/).
 
-### How you can access and control the information we collect
-If you're already a GitHub user, you may access, update, alter, or delete your basic user profile information by [editing your user profile](https://github.com/settings/profile) or contacting {{ site.data.variables.contact.contact_support }}.
+### How we, and others, communicate with you
 
-#### Data Retention and Deletion
+We will use your email address to communicate with you, if you've said that's okay, **and only for the reasons you’ve said that’s okay**. For example, if you contact our Support team with a request, we will respond to you via email. You have a lot of control over how your email address is used and shared on and through GitHub. You may manage your communication preferences in your [user profile](https://github.com/settings/emails).
 
-GitHub will retain User Personal Information for as long as your account is active or as needed to provide you services.
+By design, the Git version control system associates many actions with a user's email address, such as commit messages. We are not able to change many aspects of the Git system. If you would like your email address to remain private, even when you’re commenting on public repositories, you can [create a private email address in your user profile](https://github.com/settings/emails). You should also [update your local Git configuration to use your private email address](/articles/setting-your-commit-email-address-on-github/). This will not change how we contact you, but it will affect how others see you. We set current users' email address private by default, but legacy GitHub users may need to update their settings. Please see more about email addresses in commit messages [here](https://help.github.com/articles/about-commit-email-addresses/).
 
-We may retain certain User Personal Information indefinitely, unless you delete it or request its deletion. For example, we don’t automatically delete inactive user accounts, so unless you choose to delete your account, we will retain your account information indefinitely.
+Depending on your email settings, GitHub may occasionally send notification emails about changes in a repository you’re watching, new features, requests for feedback, important policy changes, or offer customer support. We also send marketing emails, but only with your consent, if you opt in to our list. There's an unsubscribe link located at the bottom of each of the marketing emails we send you. Please note that you can not opt out of receiving important communications from us, such as mails from our Support team or system emails, but you can configure your notifications settings in your profile.
 
-If you would like to cancel your account or delete your User Personal Information, you may do so in your [user profile](https://github.com/settings/admin). We will retain and use your information as necessary to comply with our legal obligations, resolve disputes, and enforce our agreements, but barring legal requirements, we will delete your full profile (within reason) within 30 days.
+Our emails might contain a pixel tag, which is a small, clear image that can tell us whether or not you have opened an email and what your IP address is. We use this pixel tag to make our email more effective for you and to make sure we’re not sending you unwanted email. 
 
-### How we communicate with you
+### Resolving complaints
 
-We will use your email address to communicate with you, if you've said that's okay, **and only for the reasons you’ve said that’s okay**. You have a lot of control over how your email address is used and shared on and through GitHub. You may manage your communication preferences in your [user profile](https://github.com/settings/emails).
+If you have concerns about the way GitHub is handling your User Personal Information, please let us know immediately. We want to help. You may contact us by filling out the {{ site.data.variables.contact.contact_privacy }}. You may also email us directly at privacy@github.com with the subject line "Privacy Concerns." We will respond promptly — within 45 days at the latest.
 
-If you would like your email to remain private, even when you’re commenting on public repositories, you can [create a private email address in your user profile](https://github.com/settings/emails). You can also [update your local Git configuration to use your private email address](/articles/setting-your-commit-email-address-on-github/). This will not change how we contact you, but it will affect how others see you.
+In the coming weeks, GitHub expects to appoint a Data Protection Officer who will be responsible for oversight over our compliance with the GDPR. We will provide our Data Protection Officer's contact information here. In the meantime, you may contact our Privacy Team via any of the methods above.
 
-Depending on your email settings, GitHub may occasionally send notification emails about changes in a repository you’re watching, new features, requests for feedback, important policy changes, or offer customer support. We also send marketing emails, but only with your consent. There's an unsubscribe link located at the bottom of each of the emails we send you.
+#### Dispute resolution process
 
-Our emails might contain a pixel tag, which is a small, clear image that can tell us whether or not you have opened an email and what your IP address is. We use this pixel tag to make our email more effective for you and to make sure we’re not sending you unwanted email. If you prefer not to receive pixel tags, please opt out of marketing emails.
+In the unlikely event that a dispute arises between you and GitHub regarding our handling of your User Personal Information, we will do our best to resolve it. If we cannot, we have selected JAMS, an independent dispute resolution provider, to handle unresolved Privacy Shield complaints. If we are unable to resolve your concerns after a good faith effort to address them, you may [contact JAMS and submit a Privacy Shield claim](https://www.jamsadr.com/file-an-eu-us-privacy-shield-or-safe-harbor-claim). JAMS is a US-based private alternate dispute resolution provider, and we have contracted with JAMS to provide an independent recourse mechanism for any of our users for privacy concerns **at no cost to you.** You do not need to appear in court; you may conduct this dispute resolution process via telephone or video conference. If you are not based in the EU or EEA, but you would still like to use the JAMS arbitration process to resolve your dispute, please let us know and we will provide access to you.
+
+#### Independent arbitration
+
+Under certain limited circumstances, European Union individuals may invoke binding Privacy Shield arbitration as a last resort if all other forms of dispute resolution have been unsuccessful. To learn more about this method of resolution and its availability to you, please read more about [Privacy Shield](https://www.privacyshield.gov/article?id=ANNEX-I-introduction). Arbitration is not mandatory; it is a tool you can use if you choose to.
+
+We are subject to the jurisdiction of the Federal Trade Commission.
 
 ### Changes to our Privacy Statement
-Although most changes are likely to be minor, GitHub may change our Privacy Statement from time to time. We will provide notification to Users of material changes to this Privacy Statement through our Website at least 30 days prior to the change taking effect by posting a notice on our home page or sending email to the email address specified in your GitHub primary account. For changes to this Privacy Statement that do not affect your rights, we encourage visitors to check this page frequently.
+Although most changes are likely to be minor, GitHub may change our Privacy Statement from time to time. We will provide notification to Users of material changes to this Privacy Statement through our Website at least 30 days prior to the change taking effect by posting a notice on our home page or sending email to the primary email address specified in your GitHub account. We will also update our [Site Policy](https://github.com/github/site-policy/) repository, which tracks all changes to this policy. For changes to this Privacy Statement that do not affect your rights, we encourage visitors to check our Site Policy repository frequently.
 
 ### License
 This Privacy Statement is licensed under this [Creative Commons Zero license](https://creativecommons.org/publicdomain/zero/1.0/). For details, see our [site-policy repository](https://github.com/github/site-policy#license).

--- a/Policies/github-privacy-statement.md
+++ b/Policies/github-privacy-statement.md
@@ -25,15 +25,15 @@ Of course, the short version doesn't tell you everything, so please read on for 
 | [What information GitHub collects and why](#what-information-github-collects-and-why) | GitHub collects basic information from visitors to our website, and some personal information from our users. We only require the minimum amount of personal information necessary from you. This section gives details. |
 | [What information GitHub does not collect](#what-information-github-does-not-collect) | We don’t collect information from children under 13, and we don’t collect sensitive data. |
 | [How we share the information we collect](#how-we-share-the-information-we-collect) | We share information to provide the service to you, to comply with your requests, or with our vendors. We do not host advertising on GitHub and we do not sell your personal information. You can see a list of the vendors that access your personal information. |
-| [How you can access and control the information we collect](#how-you-can-access-and-control-the-information-we-collect) | We provide ways for you to access, alter, or delete your profile information. You can also contact Support for more help. | 
+| [How you can access and control the information we collect](#how-you-can-access-and-control-the-information-we-collect) | We provide ways for you to access, alter, or delete your profile information. You can also contact Support for more help. |
 | [Our use of cookies and tracking](#our-use-of-cookies-and-tracking) | We use cookies for the overall functionality of our website, and we use a small number of tracking and analytics services on a few parts of our site. We offer a page that makes this very transparent. Please see this section for more information. |
-| [How GitHub secures your information](#how-github-secures-your-information) | We take all measures reasonably necessary to protect the confidentiality, integrity, and availability of your personal information on GitHub and to protect the resiliance of our servers as they host your information. | 
-| [GitHub's global privacy practices](#githubs-global-privacy-practices) | GitHub complies with both the EU-US Privacy Shield Framework and the General Data Protection Regulation. Please see this section for more specific information. | 
-| [How we respond to compelled disclosure](#how-we-respond-to-compelled-disclosure) | We may share your information in response to a warrant, subpoena, or other court action, or if disclosure is necessary to protect our rights or the rights of the public at large. We strive for transparency, and will notify you when possible. | 
-| [How we communicate with you](#how-we-communicate-with-you) | We communicate with you by email. You can control the way we contact you in your account settings. | 
-| [Resolving complaints](#resolving-complaints) | In the unlikely event that we are unable to resolve a privacy concern quickly and thoroughly, we provide a path of dispute resolution through external arbiters. | 
-| [Changes to our Privacy Statement](#changes-to-our-privacy-statement) | We will notify you of material changes to this Privacy Statement 30 days in advance of any such changes becoming effective. You may also track changes in our Site Policy repository. | 
-| [Contacting GitHub](#contacting-github) | Please feel free to contact us if you have questions about our Privacy Statement. | 
+| [How GitHub secures your information](#how-github-secures-your-information) | We take all measures reasonably necessary to protect the confidentiality, integrity, and availability of your personal information on GitHub and to protect the resiliance of our servers as they host your information. |
+| [GitHub's global privacy practices](#githubs-global-privacy-practices) | GitHub complies with both the EU-US Privacy Shield Framework and the General Data Protection Regulation. Please see this section for more specific information. |
+| [How we respond to compelled disclosure](#how-we-respond-to-compelled-disclosure) | We may share your information in response to a warrant, subpoena, or other court action, or if disclosure is necessary to protect our rights or the rights of the public at large. We strive for transparency, and will notify you when possible. |
+| [How we, and others, communicate with you](#how-we-and-others-communicate-with-you) | We communicate with you by email. You can control the way we contact you in your account settings. |
+| [Resolving complaints](#resolving-complaints) | In the unlikely event that we are unable to resolve a privacy concern quickly and thoroughly, we provide a path of dispute resolution through external arbiters. |
+| [Changes to our Privacy Statement](#changes-to-our-privacy-statement) | We will notify you of material changes to this Privacy Statement 30 days in advance of any such changes becoming effective. You may also track changes in our Site Policy repository. |
+| [Contacting GitHub](#contacting-github) | Please feel free to contact us if you have questions about our Privacy Statement. |
 
 ### GitHub Privacy Statement
 
@@ -45,7 +45,7 @@ If you're **just browsing the website**, we collect the same basic information t
 
 The information we collect about all visitors to our website includes the visitor’s browser type, language preference, referring site, additional websites requested, and the date and time of each visitor request. We also collect potentially personally-identifying information like Internet Protocol (IP) addresses.
 
-##### Why we collect this
+##### Why we collect this information
 
 We collect this information to better understand how our website visitors use GitHub, and to monitor and protect the security of the website.
 
@@ -62,7 +62,7 @@ User Personal Information does not include aggregated, non-personally identifyin
 - We need your User Personal Information to create your account, and to provide the services you request, including to provide the GitHub service, the Marketplace service, or to respond to support requests.
 - We use your User Personal Information, specifically your user name, to identify you on GitHub.
 - We use it to fill out your profile and share that profile with other users if you ask us to.
-- We will use your email address to communicate with you, if you've said that's okay, **and only for the reasons you’ve said that’s okay**. Please see our section on [email communication](#how-we-communicate-with-you) for more information. 
+- We will use your email address to communicate with you, if you've said that's okay, **and only for the reasons you’ve said that’s okay**. Please see our section on [email communication](#how-we-and-others-communicate-with-you) for more information.
 - We use User Personal Information to make recommendations for you, such as to suggest projects you may want to follow or contribute to. For example, when you fill out your biography in your Account Settings, we learn from it — as well as from your public behavior on GitHub — to determine your coding interests. These recommendations are automated decisions, but they have no legal impact on your rights.
 - We use your User Personal Information for internal purposes, such as to maintain logs for security reasons, for training purposes, and for legal documentation.
 - We limit our use of your User Personal Information to the purposes listed in this Privacy Statement. If we need to use your User Personal Information for other purposes, we will ask your permission first. You can always see what information we have, how we're using it, and what permissions you have given us in your [user profile](https://github.com/settings/admin).
@@ -72,17 +72,17 @@ User Personal Information does not include aggregated, non-personally identifyin
 Under certain international laws (including GDPR), GitHub is required to notify you about the legal basis on which we process User Personal Information. GitHub processes User Personal Information on the following legal bases:
 
 - When you create a GitHub account, you provide your user name and an email address. We require those data elements for you to enter into the Terms of Service agreement with us, and we process those elements on the basis of performing that contract. We also process your user name and email address on other bases. If you have a GitHub Hosted, GitHub Enterprise, or other paid account with us, there will be other data elements we must collect and process on the basis of performing that contract. GitHub does not collect or process a credit card number, but our third-party payment processor does.
-- When you fill out the information in your [user profile](https://github.com/settings/profile), you have the option to provide User Personal Information such as your full name, an avatar which may include a photograph, your biography, your location, your company, and a URL to a third party website. You have the option of setting a publicly visible email address here. We process this information on the basis of consent. All of this information is entirely optional, and you have the ability to access, modify, and delete it at any time (while you are not able to delete your email address entirely, you can set it private). 
+- When you fill out the information in your [user profile](https://github.com/settings/profile), you have the option to provide User Personal Information such as your full name, an avatar which may include a photograph, your biography, your location, your company, and a URL to a third party website. You have the option of setting a publicly visible email address here. We process this information on the basis of consent. All of this information is entirely optional, and you have the ability to access, modify, and delete it at any time (while you are not able to delete your email address entirely, you can make it private).
 - Generally, the remainder of the processing of personal information we perform is necessary for the purposes of our legitimate interests. For example, for security purposes, we must keep logs of IP addresses that access GitHub, and in order to respond to legal process, we are required to keep records of users who have sent and received DMCA takedown notices.
-- If you would like to request erasure of data we process on the basis of consent or object to our processing of personal information, please use our {{ site.data.variables.contact.contact_privacy }}. 
+- If you would like to request erasure of data we process on the basis of consent or object to our processing of personal information, please use our {{ site.data.variables.contact.contact_privacy }}.
 
 ### What information GitHub does not collect
 
-We do not intentionally collect **sensitive personal information**, such as social security numbers, genetic data, health information, or religious information. Although GitHub does not request or intentionally collect any sensitive personal information, we realize that you might store this kind of information in your account, such as in a repository. If you store any sensitive personal information on our servers, you are responsible for complying with any regulatory controls regarding that data.
+We do not intentionally collect **sensitive personal information**, such as social security numbers, genetic data, health information, or religious information. Although GitHub does not request or intentionally collect any sensitive personal information, we realize that you might store this kind of information in your account, such as in a repository or in your public profile. If you store any sensitive personal information on our servers, you are responsible for complying with any regulatory controls regarding that data.
 
-If you're a **child under the age of 13**, you may not have an account on GitHub. GitHub does not knowingly collect information from or direct any of our content specifically to children under 13. If we learn or have reason to suspect that you are a user who is under the age of 13, we will unfortunately have to close your account. We don't want to discourage you from learning to code, but those are the rules. Please see our [Terms of Service](/articles/github-terms-of-service/) for information about account termination. Other countries may have different minimum age limits, and if you are below the minimum age for providing consent for data collection in your country, you may not use GitHub without obtaining your parents' or legal guardians' consent. 
+If you're a **child under the age of 13**, you may not have an account on GitHub. GitHub does not knowingly collect information from or direct any of our content specifically to children under 13. If we learn or have reason to suspect that you are a user who is under the age of 13, we will unfortunately have to close your account. We don't want to discourage you from learning to code, but those are the rules. Please see our [Terms of Service](/articles/github-terms-of-service/) for information about account termination. Other countries may have different minimum age limits, and if you are below the minimum age for providing consent for data collection in your country, you may not use GitHub without obtaining your parents' or legal guardians' consent.
 
-We do not intentionally collect User Personal Information that is **stored in your repositories** or other free-form content inputs. Information in your repositories belongs to you, and you are responsible for it, as well as for making sure that your content complies with our [Terms of Service](/articles/github-terms-of-service/). Any personal information within a user's repository is the responsibility of the repository owner. 
+We do not intentionally collect User Personal Information that is **stored in your repositories** or other free-form content inputs. Information in your repositories belongs to you, and you are responsible for it, as well as for making sure that your content complies with our [Terms of Service](/articles/github-terms-of-service/). Any personal information within a user's repository is the responsibility of the repository owner.
 
 #### Repository contents
 
@@ -96,23 +96,23 @@ Please see more about [User Personal Information in public repositories](#public
 
 We do share User Personal Information with your permission, so we can perform services you have requested or communicate on your behalf. For example, if you purchase an integration or other Developer Product from our Marketplace, we will share your account name to allow the integrator to provide you services. Additionally, you may indicate, through your actions on GitHub, that you are willing to share your User Personal Information. For example, if you join an organization, the owner of the organization will have the ability to view your activity in the organization's access log. We will respect your choices.
 
-We **do not** share, sell, rent, or trade User Personal Information with third parties for their commercial purposes, expect where you have specifically told us to (such as by buying an integration from Marketplace).
+We **do not** share, sell, rent, or trade User Personal Information with third parties for their commercial purposes, except where you have specifically told us to (such as by buying an integration from Marketplace).
 
-We **do not** host advertising on GitHub. We may occasionally embed content from third party sites, such as YouTube, and that content may include ads. While we try to minimize the amount of ads our embedded content contains, we can't always control what third parties show. Any advertisements on individual GitHub Pages or in GitHub repositories are not sponsored by, or tracked by, GitHub. 
+We **do not** host advertising on GitHub. We may occasionally embed content from third party sites, such as YouTube, and that content may include ads. While we try to minimize the amount of ads our embedded content contains, we can't always control what third parties show. Any advertisements on individual GitHub Pages or in GitHub repositories are not sponsored by, or tracked by, GitHub.
 
 We **do not** disclose User Personal Information outside GitHub, except in the situations listed in this section or in the section below on [Compelled Disclosure](#how-we-respond-to-compelled-disclosure).
 
-We **do** share certain aggregated, non-personally identifying information with others about how our users, collectively, use GitHub, or how our users respond to our other offerings, such as our conferences or events. For example, we may [compile statistics on the usage of open source licenses across GitHub](https://github.com/blog/1964-open-source-license-usage-on-github-com). However, we do not sell this information to advertisers or marketers.
+We **do** share certain aggregated, non-personally identifying information with others about how our users, collectively, use GitHub, or how our users respond to our other offerings, such as our conferences or events. For example, we may [compile statistics on the usage of open source licenses across GitHub](https://blog.github.com/2015-03-09-open-source-license-usage-on-github-com/). However, we do not sell this information to advertisers or marketers.
 
 We **do** share User Personal Information with a limited number of third party vendors who process it on our behalf to provide or improve our service, and who have agreed to privacy restrictions similar to our own Privacy Statement by signing data protection agreements. Our vendors perform services such as payment processing, customer support ticketing, network data transmission, and other similar services. When we transfer your data to our vendors under [Privacy Shield](/articles/github-privacy-statement/#githubs-global-privacy-practices), we remain responsible for it. While GitHub processes all User Personal Information in the United States, our third party vendors may process data outside of the United States or the European Union. If you would like to know who our third party vendors are, please see our page on [Subprocessors](/articles/github-subprocessors-and-cookies/).
 
-We do share aggregated, non-personally identifying information with third parties. For example, we share the number of stars on a repository, or in the event of a security incident, we may share the number of times a particular file was accessed. 
+We do share aggregated, non-personally identifying information with third parties. For example, we share the number of stars on a repository, or in the event of a security incident, we may share the number of times a particular file was accessed.
 
 We may share User Personal Information if we are involved in a merger, sale, or acquisition. If any such change of ownership happens, we will ensure that it is under terms that preserve the confidentiality of User Personal Information, and we will notify you on our website or by email before any transfer of your User Personal Information. The organization receiving any User Personal Information will have to honor any promises we have made in our Privacy Statement or in our Terms of Service.
 
 #### Public information on GitHub
 
-Much of GitHub is public-facing. If your content is public-facing, third parties may access and use it in compliance with our Terms of Service, such as by viewing your profile or repositories or pulling data via our API. We do not sell that content; it is yours. However, we do allow third parties, such as research organizations or archives, to compile public-facing GitHub information. Other third parties, such as data brokers, have been known to scrape GitHub and compile data as well. 
+Much of GitHub is public-facing. If your content is public-facing, third parties may access and use it in compliance with our Terms of Service, such as by viewing your profile or repositories or pulling data via our API. We do not sell that content; it is yours. However, we do allow third parties, such as research organizations or archives, to compile public-facing GitHub information. Other third parties, such as data brokers, have been known to scrape GitHub and compile data as well.
 
 Your Personal Information, associated with your content, could be gathered by third parties in these compilations of GitHub data. If you do not want your Personal Information to appear in third parties’ compilations of GitHub data, please do not make your Personal Information publicly available and be sure to [configure your email address to be private in your user profile](https://github.com/settings/emails). We set current users' email address private by default, but legacy GitHub users may need to update their settings.
 
@@ -126,11 +126,15 @@ You have the option of enabling or adding third party applications, known as "De
 
 #### GitHub applications
 
-You also have the option of adding applications from GitHub, such as our Desktop app, our Mobile app, or other account features, to your account. These applications each have their own terms and may collect different kinds of User Personal Information; however, all GitHub applications are subject to this Privacy Statement, and we will always collect the minimum amount of User Personal Information necessary, and use it only for the purpose for which you have given it to us.
+You also have the option of adding applications from GitHub, such as our Desktop app, our Electron or Atom applications, or other account features, to your account. These applications each have their own terms and may collect different kinds of User Personal Information; however, all GitHub applications are subject to this Privacy Statement, and we will always collect the minimum amount of User Personal Information necessary, and use it only for the purpose for which you have given it to us.
 
 ### How you can access and control the information we collect
 
-If you're already a GitHub user, you may access, update, alter, or delete your basic user profile information by [editing your user profile](https://github.com/settings/profile) or contacting {{ site.data.variables.contact.contact_support }}. You can control the information we collect about you by limiting what information is in your profile, by updating out of date information, or by contacting {{ site.data.variables.contact.contact_support }}.  
+If you're already a GitHub user, you may access, update, alter, or delete your basic user profile information by [editing your user profile](https://github.com/settings/profile) or contacting {{ site.data.variables.contact.contact_support }}. You can control the information we collect about you by limiting what information is in your profile, by updating out of date information, or by contacting {{ site.data.variables.contact.contact_support }}.
+
+#### Data portability
+
+As a GitHub User, you can always take your data with you. You can [clone your repositories to your desktop](https://help.github.com/desktop/guides/contributing-to-projects/cloning-a-repository-from-github-desktop/), for example, or you can use our [Data Portability tools](https://developer.github.com/changes/2018-05-24-user-migration-api/) to download all of the data we have about you.
 
 #### Data retention and deletion
 
@@ -139,6 +143,8 @@ Generally, GitHub will retain User Personal Information for as long as your acco
 We may retain certain User Personal Information indefinitely, unless you delete it or request its deletion. For example, we don’t automatically delete inactive user accounts, so unless you choose to delete your account, we will retain your account information indefinitely.
 
 If you would like to cancel your account or delete your User Personal Information, you may do so in your [user profile](https://github.com/settings/admin). We will retain and use your information as necessary to comply with our legal obligations, resolve disputes, and enforce our agreements, but barring legal requirements, we will delete your full profile (within reason) within 90 days. You may contact {{ site.data.variables.contact.contact_support }} to request the erasure of the data we process on the basis of consent within 30 days.
+
+After an account has been deleted, certain data, such as contributions to others' repositories and comments in others' issues, will remain. However, we will delete or deidentify your personal information, including your user name and email address, from the author field (see https://github.com/ghost). 
 
 ### Our use of cookies and tracking
 
@@ -152,21 +158,21 @@ We provide a web page on [cookies and tracking](/articles/github-subprocessors-a
 
 We use a number of third party analytics and service providers to help us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. We only use these third party analytics providers on certain areas of our website, and all of them have signed data protection agreements with us that limit the type of personal information they can collect and the purpose for which they can process the information. In addition, we use our own internal analytics software to provide features and improve our content and performance.
 
-We do not currently respond to your browser's Do Not Track signal, and we do not permit third parties other than our analytics and service providers to track GitHub users' activity over time on GitHub. We do not track your online browsing activity on other online services over time. 
+We do not currently respond to your browser's Do Not Track signal, and we do not permit third parties other than our analytics and service providers to track GitHub users' activity over time on GitHub. We do not track your online browsing activity on other online services over time.
 
 ### How GitHub secures your information
 
-GitHub takes all measures reasonably necessary to protect User Personal Information from unauthorized access, alteration, or destruction; maintain data accuracy; and help ensure the appropriate use of User Personal Information. 
+GitHub takes all measures reasonably necessary to protect User Personal Information from unauthorized access, alteration, or destruction; maintain data accuracy; and help ensure the appropriate use of User Personal Information.
 
-GitHub enforces a written security information program. Our program: 
+GitHub enforces a written security information program. Our program:
 
 - aligns with industry recognized frameworks;  
-- includes security safeguards reasonably designed to protect the confidentiality, integrity, availability, and resilience of our users' data; 
-- is appropriate to the nature, size, and complexity of GitHub’s business operations; 
-- includes incident response and data breach notification processes; and 
-- complies with applicable information security related laws and regulations in the geographic regions where GitHub does business. 
+- includes security safeguards reasonably designed to protect the confidentiality, integrity, availability, and resilience of our users' data;
+- is appropriate to the nature, size, and complexity of GitHub’s business operations;
+- includes incident response and data breach notification processes; and
+- complies with applicable information security related laws and regulations in the geographic regions where GitHub does business.
 
-In the event of a data breach that affects your User Personal Information, we will act promptly to mitigate the impact of a breach and notify any affected users. 
+In the event of a data breach that affects your User Personal Information, we will act promptly to mitigate the impact of a breach and notify any affected users.
 
 Transmission of data on GitHub is encrypted using SSH, HTTPS, and SSL/TLS. While our data is not encrypted at rest, we manage our own cages and racks at top-tier data centers with excellent physical and network security, and when data is stored with a third party storage provider, it is encrypted.
 
@@ -176,17 +182,17 @@ No method of transmission, or method of electronic storage, is 100% secure. Ther
 
 **We store and process the information that we collect in the United States** in accordance with this Privacy Statement (our subprocessors may store and process data outside the United States). However, we understand that we have users from different countries and regions with different privacy expectations, and we try to meet those needs even when the United States does not have the same privacy framework as other countries'.
 
-We provide the same standard of privacy protection — as described in this Privacy Statement — to all our users around the world, regardless of their country of origin or location, and we are proud of the levels of notice, choice, accountability, security, data integrity, access, and recourse we provide. We have appointed a Privacy Counsel and we work hard to comply with the applicable data privacy laws wherever we do business, and we also expect to appoint a Data Protection Officer to oversee our compliance efforts. Additionally, if our vendors or affiliates have access to User Personal Information, they must sign agreements that require them to comply with our privacy policies and with applicable data privacy laws.
+We provide the same standard of privacy protection — as described in this Privacy Statement — to all our users around the world, regardless of their country of origin or location, and we are proud of the levels of notice, choice, accountability, security, data integrity, access, and recourse we provide. We have appointed a Privacy Counsel and we work hard to comply with the applicable data privacy laws wherever we do business, and our Privacy Counsel also acts as our Data Protection Officer, part of a cross-functional team that oversees our privacy compliance efforts. Additionally, if our vendors or affiliates have access to User Personal Information, they must sign agreements that require them to comply with our privacy policies and with applicable data privacy laws.
 
 In particular:
--	GitHub provides clear methods of unambiguous, informed consent at the time of data collection, when we do collect your personal data using consent as a basis. 
--	We collect only the minimum amount of personal data necessary for our purposes, unless you choose to provide more. We encourage you to only give us the amount of data you are comfortable sharing. 
+-	GitHub provides clear methods of unambiguous, informed consent at the time of data collection, when we do collect your personal data using consent as a basis.
+-	We collect only the minimum amount of personal data necessary for our purposes, unless you choose to provide more. We encourage you to only give us the amount of data you are comfortable sharing.
 -	We offer you simple methods of accessing, correcting, or deleting the User Personal Information we have collected.
 -	We provide our users notice, choice, accountability, security, and access, and we limit the purpose for processing. We also provide our users a method of recourse and enforcement. These are the Privacy Shield Principles, but they are also just good practices.
 
 #### Cross-border data transfers
 
-For cross-border data transfers from the European Union (EU) and the European Economic Area (EEA), GitHub adheres to the [Privacy Shield Framework](https://www.privacyshield.gov/). You may view our entry in the [Privacy Shield List](https://www.privacyshield.gov/participant?id=a2zt000000001K2AAI). 
+For cross-border data transfers from the European Union (EU) and the European Economic Area (EEA), GitHub adheres to the [Privacy Shield Framework](https://www.privacyshield.gov/). You may view our entry in the [Privacy Shield List](https://www.privacyshield.gov/participant?id=a2zt000000001K2AAI).
 
 In addition to providing our users methods of unambiguous, informed consent and control over their data, we participate in and comply with the Privacy Shield framework, and we are committed to subject any Personal Information we receive from the EU and EEA to the Privacy Shield Principles. In addition, we continue to participate in the Safe Harbor Framework for Swiss data transfers to the US. Please read more about [GitHub's international privacy commitments](/articles/global-privacy-practices/).
 
@@ -205,13 +211,21 @@ By design, the Git version control system associates many actions with a user's 
 
 Depending on your email settings, GitHub may occasionally send notification emails about changes in a repository you’re watching, new features, requests for feedback, important policy changes, or offer customer support. We also send marketing emails, but only with your consent, if you opt in to our list. There's an unsubscribe link located at the bottom of each of the marketing emails we send you. Please note that you can not opt out of receiving important communications from us, such as mails from our Support team or system emails, but you can configure your notifications settings in your profile.
 
-Our emails might contain a pixel tag, which is a small, clear image that can tell us whether or not you have opened an email and what your IP address is. We use this pixel tag to make our email more effective for you and to make sure we’re not sending you unwanted email. 
+Our emails might contain a pixel tag, which is a small, clear image that can tell us whether or not you have opened an email and what your IP address is. We use this pixel tag to make our email more effective for you and to make sure we’re not sending you unwanted email.
 
 ### Resolving complaints
 
 If you have concerns about the way GitHub is handling your User Personal Information, please let us know immediately. We want to help. You may contact us by filling out the {{ site.data.variables.contact.contact_privacy }}. You may also email us directly at privacy@github.com with the subject line "Privacy Concerns." We will respond promptly — within 45 days at the latest.
 
-In the coming weeks, GitHub expects to appoint a Data Protection Officer who will be responsible for oversight over our compliance with the GDPR. We will provide our Data Protection Officer's contact information here. In the meantime, you may contact our Privacy Team via any of the methods above.
+You may also contact our Data Protection Officer directly.
+
+| Our Data Protection Officer | Our EU Office |
+|---|---|
+| Hannah Poteat | GitHub BV |
+| 88 Colin P. Kelly Jr. St. | Vijzelstraat 68-72 |
+| San Francisco, CA 94107 | 1017 HL Amsterdam |
+| United States | The Netherlands |
+| privacy@github.com | privacy@github.com |
 
 #### Dispute resolution process
 

--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -1,0 +1,110 @@
+---
+title: GitHub Subprocessors and Cookies
+redirect_from:
+ - /subprocessors/
+ - /github-subprocessors/
+ - /github-tracking/
+ - /github-cookies/
+---
+
+Effective date: **April 19, 2018**
+
+GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), how we use [cookies](#cookies-on-github), and where and how we perform any [tracking on GitHub](#tracking-on-github).
+
+### GitHub Subprocessors 
+
+When we share your information with third party subprocessors, such as our vendors and service providers, we remain responsible for it. We work very hard to maintain your trust when we bring on new vendors, and we require all vendors to enter into data protection agreements with us that restrict their processing of Users' Personal Information (as defined in the [Privacy Statement](/articles/github-privacy-statement/). 
+
+| Name of Subprocessor | Description of Processing | Location of Processing |
+|---|---|---|
+| Box | Corporate document storage | United States |
+| Braintree (PayPal) | Subscription credit card payment processor | United States |
+| DocuSign | Contract signature processor | United States |
+| DropBox | Corporate document storage | United States |
+| Front | Support inbox system | United States |
+| Google Apps | Internal company infrastructure | United States |
+| Google Analytics | Website analytics and performance | United States |
+| Lithium | Community forum software provider | United States |
+| MailChimp | Customer ticketing mail services provider | United States |
+| Oracle | Corporate financial system | United States |
+| Salesforce.com | Customer relations management | United States |
+| Seal | Contract clause analysis system | United States |
+| ZenDesk | Customer support ticketing system | United States |
+| Zuora | Corporate billing system | United States |
+
+When we bring on a new vendor or other subprocessor who handles our Users' Personal Information, or remove a subprocessor, or we change how we use a subprocessor, we will update this page. 
+
+### Cookies on GitHub 
+
+GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, and provide information for future development of GitHub.
+
+A cookie is a small piece of text that our web server stores on your computer or mobile device, which your browser sends to us when you return to our site. Cookies do not necessarily identify you if you are merely visiting GitHub; however, a cookie may store a unique identifier for each logged in user. The cookies GitHub sets are essential for the operation of the website, or are used for performance or functionality. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept cookies, you will not be able to log in or use GitHub’s services.
+
+GitHub sets the following cookies on our users for the following reasons:
+
+| Name of Cookie | Reason |
+|---|---|
+| `:user_session` | This cookie is used to log you in. |
+| `:logged_in` | This cookie is used to signal to us that the user is already logged in. |
+| `:dotcom_user` | This cookie is used to signal to us that the user is already logged in. |
+| `:_gh_sess` | This cookie is used for temporary application and framework state between pages like what step the user is on in a multiple step form. |
+| `:tz` | This cookie allows your browser to tell us what time zone you're in. |
+| `:gist_user_session` | This cookie is used by Gist when running on a separate host. |
+| `:saml_csrf_token` | This cookie is set by SAML auth path method to associate a token with the client. |
+| `:saml_return_to` | This cookie is set by the SAML auth path method to maintain state during the SAML authentication loop. |
+| `:gist_oauth_csrf` | This cookie is set by Gist to ensure the user that started the oauth flow is the same user that completes it. |
+| `:"__Host-user_session_same_site"` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
+| `:"__Host-gist_user_session_same_site"` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
+| `:_ga` | This cookie is used by Google Analytics. |
+| `:_octo` | This cookie is used by Octolytics, our internal analytics service, to distinguish unique users and clients. |
+| `:tracker` | This cookie tracks the referring source for signup analytics. |
+
+Certain pages on our site may set other third party cookies. For example, we may embed content, such as videos, from another site that sets a cookie. While we try to minimize these third party cookies, we can’t always control what cookies this third party content sets.
+
+### Tracking on GitHub
+
+"[Do Not Track](https://www.eff.org/issues/do-not-track)" is a privacy preference you can set in your browser if you do not want online services — specifically ad networks — to collect and share certain kinds of information about your online activity from third party tracking services. GitHub does not currently respond differently to an individual browser's Do Not Track setting. If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://www.eff.org/privacybadger). 
+
+We do not track your online browsing activity on other online services over time and we do not host third-party advertising on GitHub that might track your activity on our site. We do have agreements with certain vendors, such as analytics providers, who help us track visitors' movements on certain pages on our site. Only our vendors, who are collecting data on our behalf, may collect data on our pages, and we have signed data protection agreements with every vendor who collects this data on our behalf. We use the data we receive from these vendors to better understand our visitors' interests, to understand our website's performance, and to improve our content. Any analytics vendor will be listed in our Subprocessor List above, and you may see a list of every page where we collect this kind of data below.
+
+#### Google Analytics
+
+We use Google Analytics as a third party analytics service, but we don’t use it for advertising purposes. We use Google Analytics to collect information about how our website performs and how our users, in general, navigate through and use GitHub. This helps us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. Google provides further information about its own privacy practices and [offers a browser add-on to opt out of Google Analytics tracking](https://tools.google.com/dlpage/gaoptout).
+
+#### Pages on GitHub where analytics is enabled
+
+The following pages on our main site may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
+
+- github.com/home (if you are logged out or do not have an account, this is the page you will see when you go to github.com)
+- github.com/about
+   - github.com/about/careers
+   - github.com/about/press
+- github.com/blog
+- github.com/business
+   - github.com/business/customers
+   - github.com/business/customers/{$customer}
+ - github.com/business/security
+- github.com/collections
+- github.com/developer-stories
+   - github.com/developer-stories/{$developer}
+- github.com/events
+- github.com/explore
+- github.com/features
+   - github.com/features/code-review
+   - github.com/features/project-management
+   - github.com/features/integrations
+- github.com/logos
+- github.com/nonprofit
+- github.com/open-source
+   - github.com/open-source/stories
+   - github.com/open-source/stories/{$maintainer}
+- github.com/personal
+- github.com/pricing
+   - github.com/pricing/developer
+   - github.com/pricing/team
+   - github.com/pricing/business-hosted
+   - github.com/pricing/business-enterprise
+- github.com/ten
+- github.com/trending
+- github.com/updates
+   - github.com/updates/satellite-2017

--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -7,34 +7,37 @@ redirect_from:
  - /github-cookies/
 ---
 
-Effective date: **April 19, 2018**
+Effective date: **May 25, 2018**
 
 GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), how we use [cookies](#cookies-on-github), and where and how we perform any [tracking on GitHub](#tracking-on-github).
 
-### GitHub Subprocessors 
+### GitHub Subprocessors
 
-When we share your information with third party subprocessors, such as our vendors and service providers, we remain responsible for it. We work very hard to maintain your trust when we bring on new vendors, and we require all vendors to enter into data protection agreements with us that restrict their processing of Users' Personal Information (as defined in the [Privacy Statement](/articles/github-privacy-statement/). 
+When we share your information with third party subprocessors, such as our vendors and service providers, we remain responsible for it. We work very hard to maintain your trust when we bring on new vendors, and we require all vendors to enter into data protection agreements with us that restrict their processing of Users' Personal Information (as defined in the [Privacy Statement](/articles/github-privacy-statement/).
 
 | Name of Subprocessor | Description of Processing | Location of Processing |
 |---|---|---|
 | Box | Corporate document storage | United States |
 | Braintree (PayPal) | Subscription credit card payment processor | United States |
 | DocuSign | Contract signature processor | United States |
-| DropBox | Corporate document storage | United States |
+| Dropbox | Corporate document storage | United States |
 | Front | Support inbox system | United States |
 | Google Apps | Internal company infrastructure | United States |
 | Google Analytics | Website analytics and performance | United States |
 | Lithium | Community forum software provider | United States |
 | MailChimp | Customer ticketing mail services provider | United States |
+| Mailgun | Transactional mail services provider | United States |
+| Nexmo | SMS notification provider | United States |
 | Oracle | Corporate financial system | United States |
 | Salesforce.com | Customer relations management | United States |
-| Seal | Contract clause analysis system | United States |
-| ZenDesk | Customer support ticketing system | United States |
+| Sendgrid | Transactional mail services provider | United States |
+| Twilio | SMS notification provider | United States | 
+| Zendesk | Customer support ticketing system | United States |
 | Zuora | Corporate billing system | United States |
 
-When we bring on a new vendor or other subprocessor who handles our Users' Personal Information, or remove a subprocessor, or we change how we use a subprocessor, we will update this page. 
+When we bring on a new vendor or other subprocessor who handles our Users' Personal Information, or remove a subprocessor, or we change how we use a subprocessor, we will update this page. If you have questions or concerns about a new subprocessor, we'd be happy to help. Please contact us via {{ site.data.variables.contact.contact_privacy }}.
 
-### Cookies on GitHub 
+### Cookies on GitHub
 
 GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, and provide information for future development of GitHub.
 
@@ -44,26 +47,26 @@ GitHub sets the following cookies on our users for the following reasons:
 
 | Name of Cookie | Reason |
 |---|---|
-| `:user_session` | This cookie is used to log you in. |
-| `:logged_in` | This cookie is used to signal to us that the user is already logged in. |
-| `:dotcom_user` | This cookie is used to signal to us that the user is already logged in. |
-| `:_gh_sess` | This cookie is used for temporary application and framework state between pages like what step the user is on in a multiple step form. |
-| `:tz` | This cookie allows your browser to tell us what time zone you're in. |
-| `:gist_user_session` | This cookie is used by Gist when running on a separate host. |
-| `:saml_csrf_token` | This cookie is set by SAML auth path method to associate a token with the client. |
-| `:saml_return_to` | This cookie is set by the SAML auth path method to maintain state during the SAML authentication loop. |
-| `:gist_oauth_csrf` | This cookie is set by Gist to ensure the user that started the oauth flow is the same user that completes it. |
-| `:"__Host-user_session_same_site"` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
-| `:"__Host-gist_user_session_same_site"` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
-| `:_ga` | This cookie is used by Google Analytics. |
-| `:_octo` | This cookie is used by Octolytics, our internal analytics service, to distinguish unique users and clients. |
-| `:tracker` | This cookie tracks the referring source for signup analytics. |
+| `user_session` | This cookie is used to log you in. |
+| `logged_in` | This cookie is used to signal to us that the user is already logged in. |
+| `dotcom_user` | This cookie is used to signal to us that the user is already logged in. |
+| `_gh_sess` | This cookie is used for temporary application and framework state between pages like what step the user is on in a multiple step form. |
+| `tz` | This cookie allows your browser to tell us what time zone you're in. |
+| `gist_user_session` | This cookie is used by Gist when running on a separate host. |
+| `saml_csrf_token` | This cookie is set by SAML auth path method to associate a token with the client. |
+| `saml_return_to` | This cookie is set by the SAML auth path method to maintain state during the SAML authentication loop. |
+| `gist_oauth_csrf` | This cookie is set by Gist to ensure the user that started the oauth flow is the same user that completes it. |
+| `__Host-user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
+| `__Host-gist_user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
+| `_ga` | This cookie is used by Google Analytics. |
+| `_octo` | This cookie is used by Octolytics, our internal analytics service, to distinguish unique users and clients. |
+| `tracker` | This cookie tracks the referring source for signup analytics. |
 
 Certain pages on our site may set other third party cookies. For example, we may embed content, such as videos, from another site that sets a cookie. While we try to minimize these third party cookies, we can’t always control what cookies this third party content sets.
 
 ### Tracking on GitHub
 
-"[Do Not Track](https://www.eff.org/issues/do-not-track)" is a privacy preference you can set in your browser if you do not want online services — specifically ad networks — to collect and share certain kinds of information about your online activity from third party tracking services. GitHub does not currently respond differently to an individual browser's Do Not Track setting. If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://www.eff.org/privacybadger). 
+"[Do Not Track](https://www.eff.org/issues/do-not-track)" is a privacy preference you can set in your browser if you do not want online services — specifically ad networks — to collect and share certain kinds of information about your online activity from third party tracking services. GitHub does not currently respond differently to an individual browser's Do Not Track setting. If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://www.eff.org/privacybadger).
 
 We do not track your online browsing activity on other online services over time and we do not host third-party advertising on GitHub that might track your activity on our site. We do have agreements with certain vendors, such as analytics providers, who help us track visitors' movements on certain pages on our site. Only our vendors, who are collecting data on our behalf, may collect data on our pages, and we have signed data protection agreements with every vendor who collects this data on our behalf. We use the data we receive from these vendors to better understand our visitors' interests, to understand our website's performance, and to improve our content. Any analytics vendor will be listed in our Subprocessor List above, and you may see a list of every page where we collect this kind of data below.
 
@@ -71,7 +74,7 @@ We do not track your online browsing activity on other online services over time
 
 We use Google Analytics as a third party analytics service, but we don’t use it for advertising purposes. We use Google Analytics to collect information about how our website performs and how our users, in general, navigate through and use GitHub. This helps us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. Google provides further information about its own privacy practices and [offers a browser add-on to opt out of Google Analytics tracking](https://tools.google.com/dlpage/gaoptout).
 
-#### Pages on GitHub where analytics is enabled
+#### Pages on GitHub where analytics may be enabled
 
 The following pages on our main site may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
 


### PR DESCRIPTION
### Updates to our Privacy Statement

Over the last few months, we've gotten a few questions asking about our General Data Protection Regulation (GDPR) compliance. We are proud to announce that we are compliant with the GDPR. Additionally, we have always provided the same level of privacy protection to our users regardless of their residency, location, or citizenship, and that will not change. We provide strong privacy and security protection to _all_ of our users.

For the most part, our changes to the Privacy Statement are only points of clarification. GitHub doesn't ask for more personal data from our users than we need to provide our services to you. Where we offer you the option of giving us more data, we provide you the ability to access and delete the data you have given us. For example, you can always remove your profile information, your comments in issues, and your repository contents. We have gone through our Privacy Statement to provide more context and transparency, though, so our users understand exactly why we ask for information and what we'll do with it.

### GDPR Compliance

* The GDPR requires us to inform our users about the legal basis on which we process their data. In this update, we explain what data we collect and why.
* We describe our security practices in more detail
* We now provide a separate page describing our tracking, our use of cookies, and listing our subprocessors (the vendors and third parties we have engaged to process personal data on our behalf)
* Throughout the Privacy Statement, we provide greater transparency and insight into our data collection, data handling, data retention, and data deletion processes
* If you are a Corporate Terms of Service customer and you need a Data Protection Agreement with us, please [contact support](https://github.com/contact). We will be happy to provide one. Please understand that with the GDPR compliance deadline coming up, our volume of requests is high, but we will respond to you as promptly as possible.

### Subprocessors, Cookies, and Tracking

We also now provide a page that lists our subprocessors, such as our vendors and service providers. We also offer some transparency into what cookies GitHub sets and why, and exactly which pages on GitHub do any tracking for analytics purposes and who our analytics providers are (at the moment, it's Google Analytics, but if that changes, we'll be able to use this page to provide greater transparency).
