### PR TITLE
Updates to the Standard Terms of Service - Spring 2018

### DIFF
--- a/Policies/github-terms-of-service.md
+++ b/Policies/github-terms-of-service.md
@@ -22,7 +22,7 @@ Thank you for using GitHub! We're happy you're here. Please read this Terms of S
 | [G. Intellectual Property Notice](#g-intellectual-property-notice) | This describes GitHub's rights in the website and service. |
 | [H. API Terms](#h-api-terms) | These are the rules for using GitHub's APIs, whether you are using the API for development or data collection. |
 | [I. Additional Terms for GitHub Pages](#i-additional-terms-for-github-pages) | We have a few specific rules for content hosted using GitHub Pages. |
-| [J. Additional Terms for GitHub Marketplace](#j-additional-terms-for-github-marketplace) | We have another set of terms for GitHub Marketplace. |
+| [J. Third Party Applications](#j-third-party-applications) | We have a few rules for creating apps for other Users, and  another set of terms for GitHub Marketplace. |
 | [K. Advertising on GitHub](#k-advertising-on-github) | If you want to promote your content on GitHub, this section lays out some rules you must follow. |
 | [L. Payment](#l-payment) | You are responsible for payment. We are responsible for billing you accurately. |
 | [M. Cancellation and Termination](#m-cancellation-and-termination) | You may cancel this agreement and close your account at any time. |
@@ -34,7 +34,7 @@ Thank you for using GitHub! We're happy you're here. Please read this Terms of S
 | [S. Miscellaneous](#s-miscellaneous) | Please see this section for legal details including our choice of law. |
 
 ### The GitHub Terms of Service
-Effective date: October 11, 2017
+Effective date: May 25, 2018
 
 
 ### A. Definitions
@@ -46,29 +46,34 @@ Effective date: October 11, 2017
 4. “The User,” “You,” and “Your” refer to the individual person, company, or organization that has visited or is using the Website or Service; that accesses or uses any part of the account; or that directs the use of the account in the performance of its functions. A User must be at least 13 years of age. Special terms may apply for business or government accounts (See [Section B(4): Additional Terms](#4-additional-terms)).
 5. “GitHub,” “We,” and “Us” refer to GitHub, Inc., as well as our affiliates, directors, subsidiaries, contractors, licensors, officers, agents, and employees.
 6. “Content” refers to content featured or displayed through the Website, including without limitation text, data, articles, images, photographs, graphics, software, applications, designs, features, and other materials that are available on the Website or otherwise available through the Service. "Content" also includes Services. “User-Generated Content” is Content, written or otherwise, created or uploaded by our Users. "Your Content" is Content that you create or own.
+7. An "Account" represents your legal relationship with GitHub. A “User Account” represents an individual User’s authorization to log in to and use the Service and serves as a User’s identity on GitHub. “Organizations” are shared workspaces that may be associated with a single entity or with one or more Users where multiple Users can collaborate across many projects at once. A User Account can be a member of any number of Organizations.
 
 ### B. Account Terms
-**Short version:** *A human must create your account; you must be 13 or over; you must provide a valid email address; and you may not have more than one free account. You alone are responsible for your account and anything that happens while you are signed in to or using your account. You are responsible for keeping your account secure.*
+**Short version:** *User Accounts and Organizations have different administrative controls; a human must create your account; you must be 13 or over; you must provide a valid email address; and you may not have more than one free account. You alone are responsible for your account and anything that happens while you are signed in to or using your account. You are responsible for keeping your account secure.*
 
-#### 1. Required Information
+#### 1. Account Controls
+- Users. Subject to these Terms, you retain ultimate administrative control over your User Account and the Content within it.
+
+- Organizations. The "owner" of an Organization that was created under these Terms has ultimate administrative control over that Organization and the Content within it. Within the Service, an owner can manage User access to the Organization’s data and projects. An Organization may have multiple owners, but there must be at least one User Account designated as an owner of an Organization. If you are the owner of an Organization under these Terms, we consider you responsible for the actions that are performed on or through that Organization.
+
+#### 2. Required Information
 You must provide a valid email address in order to complete the signup process. Any other information requested, such as your real name, is optional, unless you are accepting these terms on behalf of a legal entity (in which case we need more information about the legal entity) or if you opt for a [paid account](#l-payment), in which case additional information will be necessary for billing purposes.
 
-#### 2. Account Requirements
-We have a few simple rules for accounts on GitHub's Service.
+#### 3. Account Requirements
+We have a few simple rules for User Accounts on GitHub's Service.
 - You must be a human to create an account. Accounts registered by "bots" or other automated methods are not permitted. We do permit machine accounts:  
 - A machine account is an account set up by an individual human who accepts the Terms on behalf of the account, provides a valid email address, and is responsible for its actions. A machine account is used exclusively for performing automated tasks. Multiple users may direct the actions of a machine account, but the owner of the account is ultimately responsible for the machine's actions. You may maintain no more than one free machine account in addition to your free personal account.
 - One person or legal entity may maintain no more than one free account (if you choose to control a machine account as well, that's fine, but it can only be used for running a machine).
 - You must be age 13 or older. While we are thrilled to see brilliant young coders get excited by learning to program, we must comply with United States law. GitHub does not target our Service to children under 13, and we do not permit any Users under 13 on our Service. If we learn of any User under the age of 13, we will [terminate that User’s account immediately](#m-cancellation-and-termination). If you are a resident of a country outside the United States, your country’s minimum age may be older; in such a case, you are responsible for complying with your country’s laws.
-- Your login may only be used by one person — i.e., a single login may not be shared by multiple people. A paid organization account may create separate logins for as many users as its subscription allows.
-- Overall, the number of Users must not exceed the number of accounts you've ordered from us.
+- Your login may only be used by one person — i.e., a single login may not be shared by multiple people. A paid Organization  may only provide access to as many User Accounts as your subscription allows.
 
-#### 3. User Account Security
+#### 4. User Account Security
 You are responsible for keeping your account secure while you use our Service. We offer tools such as two-factor authentication to help you maintain your account's security, but the content of your account and its security are up to you.
 - You are responsible for all content posted and activity that occurs under your account (even when content is posted by others who have accounts under your account).
 - You are responsible for maintaining the security of your account and password. GitHub cannot and will not be liable for any loss or damage from your failure to comply with this security obligation.
 - You will promptly [notify GitHub](https://github.com/contact) if you become aware of any unauthorized use of, or access to, our Service through your account, including any unauthorized use of your password or account.
 
-#### 4. Additional Terms
+#### 5. Additional Terms
 In some situations, third parties' terms may apply to your use of GitHub. For example, you may be a member of an organization on GitHub with its own terms or license agreements; you may download an application that integrates with GitHub; or you may use GitHub to authenticate to another service. Please be aware that while these Terms are our full agreement with you, other parties' terms govern their relationships with you.
 
 If you are a government User or otherwise accessing or using any GitHub Service in a government capacity, this [Government Amendment to GitHub Terms of Service](/articles/amendment-to-github-terms-of-service-applicable-to-u-s-federal-government-users/) applies to you, and you agree to its provisions.
@@ -132,7 +137,7 @@ You may create or upload User-Generated Content while using the Service. You are
 We do not pre-screen User-Generated Content, but we have the right (though not the obligation) to refuse or remove any User-Generated Content that, in our sole discretion, violates any GitHub terms or policies.
 
 #### 3. Ownership of Content, Right to Post, and License Grants
-You retain ownership of and responsibility for Content you create or own ("Your Content"). If you're posting anything you did not create yourself or do not own the rights to, you agree that you are responsible for any Content you post; that you will only submit Content that you have the right to post; and that you will fully comply with any third party licenses relating to Content you post.
+You retain ownership of and responsibility for Your Content. If you're posting anything you did not create yourself or do not own the rights to, you agree that you are responsible for any Content you post; that you will only submit Content that you have the right to post; and that you will fully comply with any third party licenses relating to Content you post.
 
 Because you retain ownership of and responsibility for Your Content, we need you to grant us — and other GitHub Users — certain legal permissions, listed in Sections D.4 — D.7. These license grants apply to Your Content. If you upload Content that already comes with a license granting GitHub the permissions we need to run our Service, no additional license is required. You understand that you will not receive any payment for any of the rights granted in Sections D.4 — D.7. The licenses you grant to us will end when you remove Your Content from our servers, unless other Users have forked it.
 
@@ -168,11 +173,10 @@ GitHub considers the contents of private repositories to be confidential to you.
 #### 3. Access.
 GitHub employees may only access the content of your private repositories in the following situations:
 - With your consent and knowledge, for support reasons. If GitHub accesses a private repository for support reasons, we will only do so with the owner’s consent and knowledge.
-- When access is required for security reasons.
+- When access is required for security reasons, including when access is required to maintain ongoing confidentiality, integrity, availability and resilience of GitHub's systems and Service.
 
 You may choose to enable additional access to your private repositories. For example:
 - You may enable various GitHub services or features that require additional rights to Your Content in private repositories. These rights may vary depending on the service or feature, but GitHub will continue to treat your private repository Content as confidential. If those services or features require rights in addition to those we need to provide the GitHub Service, we will provide an explanation of those rights.
-- You may also grant a third-party application authorization to use, access, and disclose the contents of your private repositories. Your use of third-party applications is at your sole risk; GitHub is not liable for disclosures to third parties that you authorize to access a private repository.
 
 #### 4. Exclusions.
 If we have reason to believe the contents of a private repository are in violation of the law or of these Terms, we have the right to access, review, and remove them. Additionally, we may be [compelled by law](/articles/github-privacy-statement/#how-we-respond-to-compelled-disclosure) to disclose the contents of your private repositories.
@@ -211,19 +215,31 @@ GitHub may offer subscription-based access to our API for those Users who requir
 ### I. Additional Terms for GitHub Pages
 **Short version:** *The GitHub Pages hosting service is subject to certain rules, in addition to the rest of the Terms.*
 
-Each GitHub account comes with access to the [GitHub Pages static hosting service](https://pages.github.com/). This hosting service is intended to host static web pages for GitHub users. GitHub Pages are subject to some specific bandwidth and usage limits, and may not be appropriate for some high-bandwidth uses. Please see our [GitHub Pages guidelines](/articles/what-is-github-pages/) for more information.
+Each GitHub account comes with access to the [GitHub Pages static hosting service](https://pages.github.com/). This hosting service is intended to host static web pages for GitHub users. GitHub Pages are subject to some specific bandwidth and usage limits, and may not be appropriate for some high-bandwidth uses or other prohibited uses. Please see our [GitHub Pages guidelines](/articles/what-is-github-pages/) for more information.
 
 GitHub reserves the right at all times to reclaim any GitHub subdomain without liability.
 
-### J. Additional Terms for GitHub Marketplace
+### J. Third Party Applications
+**Short version:** *You need to follow certain rules if you create an application for other Users, and there are additional Terms that cover the Marketplace.*
 
-**Short version:** *GitHub Marketplace is subject to certain rules, in addition to the rest of this Agreement.*
+#### 1. Creating Applications
 
-[GitHub Marketplace](https://github.com/marketplace) is a platform for developers of all kinds. Through GitHub Marketplace, you can list Developer Products (as defined in the [GitHub Marketplace Terms of Service](/articles/github-marketplace-terms-of-service/)) or buy others' Developer Products. Prior to submitting a project to be listed, you must agree to the [GitHub Marketplace Developer Agreement](/articles/github-marketplace-developer-agreement/).
+If you create a third-party application or other developer product that collects User data and integrates with the Service through GitHub's API, OAuth mechanism, or otherwise ("Developer Product"), and make it available for other Users, then you must comply with the following requirements:
+- You must comply with this Agreement and the GitHub Privacy Statement.
+- You must limit your usage of the User's data you collect to that purpose for which it was collected, unless the User agrees to allow different uses. 
+- You must take all reasonable security measures appropriate to the risks, such as against accidental or unlawful destruction, or accidental loss, alteration, unauthorized disclosure or access, presented by processing the User data.
+- You must not hold yourself out as collecting any Personal Information on GitHub’s behalf, and provide sufficient notice of your privacy practices to the User, such as by posting a privacy policy.
+- Upon our reasonable request, unless prohibited by law, you must return or destroy all data at all locations where it is stored after it is no longer needed for the limited and specified purposes for which it was collected.
 
-If you buy Developer Products, the [GitHub Marketplace Terms of Service](/articles/github-marketplace-terms-of-service/) controls your purchase. This Agreement, as well as the [GitHub Marketplace Terms of Service](/articles/github-marketplace-terms-of-service/), will govern your use of GitHub Marketplace. Many of these Developer Products are used exclusively for performing automated tasks. In addition, multiple Users may direct the actions of a Developer Product. However, if you purchase and/or set up a Developer Product on your account, or you are an owner of an account with an integrated Developer Product, then you will be responsible for the Developer Product's actions that are performed on or through your account.
+If you list a Developer Product through GitHub Marketplace, then you must agree to the [GitHub Marketplace Developer Agreement](/articles/github-marketplace-developer-agreement/), prior to submitting the project to be listed. 
 
-Any violation of the [GitHub Marketplace Terms of Service](/articles/github-marketplace-terms-of-service/) is also a violation of this Agreement.
+#### 2. Using Third-Party Applications
+
+You may grant a Developer Product authorization to use, access, and disclose the contents of your repositories, including your private repositories. Some Developer Products are available through [GitHub Marketplace](https://github.com/marketplace). Some Developer Products can be used for performing automated tasks, and often times multiple Users may direct the actions of a Developer Product. However, if you purchase and/or set up a Developer Product on your account, or you are an owner of an account with an integrated Developer Product, then you will be responsible for the Developer Product's actions that are performed on or through your account. Please see our [Privacy Statement](/github-privacy-statement.md#third-party-applications) for more information about how we share data with Developer Products. 
+
+**GitHub makes no warranties of any kind in relation to Developer Products and is not liable for disclosures to third parties that you authorize to access Your Content. Your use of any third-party applications is at your sole risk.**
+
+If you buy Developer Products through GitHub Marketplace, the [GitHub Marketplace Terms of Service](/articles/github-marketplace-terms-of-service/) controls your purchase. This Agreement, as well as the [GitHub Marketplace Terms of Service](/articles/github-marketplace-terms-of-service/), will govern your use of GitHub Marketplace. 
 
 ### K. Advertising on GitHub
 **Short version:** *We do not generally prohibit use of GitHub for advertising. However, we expect our users to follow certain limitations, so GitHub does not become a spam haven. No one wants that.*
@@ -325,7 +341,7 @@ You agree to indemnify us, defend us, and hold us harmless from and against any 
 ### R. Changes to These Terms
 **Short version:** *We want our users to be informed of important changes to our terms, but some changes aren't that important — we don't want to bother you every time we fix a typo. So while we may modify this agreement at any time, we will notify users of any changes that affect your rights and give you time to adjust to them.*
 
-We reserve the right, at our sole discretion, to amend these Terms of Service at any time and will update these Terms of Service in the event of any such amendments. We will notify our Users of material changes to this Agreement, such as price changes, at least 30 days prior to the change taking effect by posting a notice on our Website. For non-material modifications, your continued use of the Website constitutes agreement to our revisions of these Terms of Service.
+We reserve the right, at our sole discretion, to amend these Terms of Service at any time and will update these Terms of Service in the event of any such amendments. We will notify our Users of material changes to this Agreement, such as price changes, at least 30 days prior to the change taking effect by posting a notice on our Website. For non-material modifications, your continued use of the Website constitutes agreement to our revisions of these Terms of Service. You can view all changes to these Terms in our [Site Policy](https://github.com/github/site-policy) repository.
 
 We reserve the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Website (or any part of it) with or without notice.
 


### PR DESCRIPTION
Most of the changes to our terms are clarifications of pre-existing sections. Here are a few sections we'd like to highlight:

* Third Party Applications: We combined the Marketplace section with general requirements for those creating integrations for other users to provide better protections for GitHub users and their data. The Marketplace section is now called "Third Party Applications," since it now applies to more than just GitHub's Marketplace. We've also added a "Third Party Applications" section to the Privacy Statement to discuss our users' privacy expectations in regards to those applications
* Access to Private Repositories: In Section E, we clarified the purposes for which we may be required to access private repository contents, in line with the security obligations of our GDPR compliance program
* More definitions: We included definitions of "User Accounts" and "Organizations" and described who has control of those types of accounts