### PR TITLE
Adding GitHub Statement Against Modern Slavery and Child Labor - 2018

### DIFF
--- a/anti-slavery-statement-2018.md
+++ b/anti-slavery-statement-2018.md
@@ -1,0 +1,103 @@
+---
+title: GitHub Statement Against Modern Slavery and Child Labor
+
+---
+*2018 statement*
+
+According to the International Labour Organization (ILO), [40 million people were victims of modern slavery and 152 million children were subject to child labor](http://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_574717/lang--en/index.htm) globally in 2016. As the [ILO reports](http://www.ilo.org/global/topics/forced-labour/lang--en/index.htm):
+   - 1 in 4 victims of modern slavery are children.
+   - Out of the 24.9 million people trapped in forced labour, 16 million people are exploited in the private sector such as domestic work, construction or agriculture; 4.8 million persons in forced sexual exploitation, and 4 million persons in forced labour imposed by state authorities.
+   -	Women and girls are disproportionately affected by forced labour, accounting for 99% of victims in the commercial sex industry, and 58% in other sectors.
+
+GitHub deplores the presence and persistence of modern slavery and child labor, and takes seriously its responsibility to ensure that neither modern slavery nor child labor takes place in its supply chain or in any part of its business. ("Modern slavery" in this statement refers to slavery, forced or compulsory labor, trafficking, servitude, and workers who are imprisoned, indentured, or bonded. "Child labor" refers to work performed by someone under 16 years of age, or under 14 for light work, provided it is not confined to periods that interfere with the child's schooling and not in conditions that interfere with the child's health or well-being.)
+
+In accordance with the [UK Modern Slavery Act](http://www.legislation.gov.uk/ukpga/2015/30/section/54/enacted), and in alignment with the [ILO 2014 Protocol to its Forced Labour Convention](http://www.ilo.org/dyn/normlex/en/f?p=NORMLEXPUB:12100:0::NO::P12100_ILO_CODE:P029), [ILO Declaration on Fundamental Principles and Rights at Work](http://www.ilo.org/declaration/thedeclaration/textdeclaration/lang--en/index.htm), and [United Nations Sustainable Development Goals target 8.7](https://sustainabledevelopment.un.org/sdg8), this 2018 Statement Against Modern Slavery and Child Labor ("the Statement") describes the steps GitHub has taken to prevent modern slavery and child labor from occurring in its business or supply chain.
+
+### GitHub's structure, business, and supply chains
+
+GitHub is a software development platform with its headquarters in San Francisco, and employees and contractors working in numerous countries.
+
+All GitHub employees and individual independent contractors are voluntary and at-will. GitHub has a largely distributed workforce, and strives to provide competitive compensation and benefits to its employees and contractors regardless of location. This is true whether we hire independent contractors directly or through an intermediary.
+
+GitHub does not conduct manufacturing or produce hardware, nor does GitHub use recruitment agencies for the kinds of services often performed by migrant workers. The nature of GitHub's business does not subject it to sudden changes in workload or pricing pressures, which often drive demand for practices that increase the risk of forced labor in supply chains, such as forced overtime.
+
+GitHub offers free and paid software and web-based software as a service to customers all over the world. GitHub's products include:
+   - GitHub.com: web-based collaboration and code-hosting platform
+   - GitHub Enterprise: on-premises collaboration and code hosting software
+   - Atom: text editor
+   - Electron: framework for writing cross-platform desktop apps
+   - GitHub Desktop: desktop app for accessing GitHub.com and GitHub Enterprise
+
+GitHub's supply chain consists of goods and services for our products and operations including computing services, event planning, purchase of retail and promotional items, office supplies, and leasing of facilities such as office space and data centers.
+
+### Policies in relation to modern slavery and child labor
+
+#### Modern slavery and child labor
+
+**GitHub's Code of Ethics** prohibits knowingly using, participating in, supporting, or tolerating modern slavery (slavery, forced or compulsory labor, trafficking, servitude, or workers who are imprisoned, indentured, or bonded) or child labor in its business operations. Any GitHub employee or contractor who violates this prohibition will be subject to termination of employment or business relationship.
+
+**GitHub's Standards of Conduct** prohibit unsafe and illegal conduct, including knowingly using, participating in, supporting, or tolerating modern slavery (slavery, forced or compulsory labor, trafficking, servitude, or workers who are imprisoned, indentured, or bonded) or child labor.
+
+GitHub complies with laws prohibiting trafficking and child labor in the jurisdictions in which it operates, including [U.S. Federal Acquisition Regulation 22.17 on combatting human trafficking](https://www.acquisition.gov/far/html/Subpart%2022_17.html).
+
+In addition, GitHub established a partnership with the FairHotel Program, which means GitHub encourages its employees to choose FairHotel endorsed hotels-where workers have fair wages, adequate benefits, and a voice on the job. Being a FairHotel partner also signifies that GitHub provides business to hotels as a fair employer.
+
+Going forward, GitHub will communicate this Statement to all employees, contractors, and suppliers, including recruiters and employment agencies. In addition, GitHub is developing training for all GitHub employees on modern slavery and child labor. GitHub [posts its Statement Against Modern Slavery and Child Labor publicly](/articles/github-statement-against-modern-slavery-and-child-labor).
+
+GitHub has a non-retaliation policy for reporting workplace-related concerns. Consistent with this Statement, GitHub allows employees and contractors to report issues regarding modern slavery and child labor without fear of retaliation.
+
+### Labor laws and practices
+
+GitHub's labor practices are
+
+**fair**:
+   - GitHub pays its employees and contractors a fair wage, in accordance with applicable legal wages
+   - GitHub maintains humane working conditions
+   - GitHub does not require workers to exceed the maximum hours of daily labor set by local and national laws or regulations
+   - GitHub pays its employees and contractors in a timely manner, with documentation (such as a pay stub) stating the basis on which they are paid, and keeps employee records in accordance with local and national laws
+
+**humane and ethical**:
+   - GitHub uses only voluntary labor
+   - GitHub prohibits child labor
+   - GitHub does not engage in physical discipline or abuse
+   - GitHub does not tolerate harassment or unlawful discrimination in the workforce or workplace
+
+**respectful**:
+   - GitHub protects its employees' rights to freedom of association and collective bargaining in accordance with legal requirements, including to post legal notices of employees' rights under the National Labor Relations Act
+   - GitHub provides benefits to employees at or in excess of levels expected in the industry
+   - GitHub encourages employees to report any workplace complaint and does not tolerate retaliation for reporting
+
+### Due diligence processes in relation to modern slavery and child labor in its business and supply chains
+
+GitHub assesses its business and supply chain for risks related to modern slavery and child labor. Drawing on internal and external human rights expertise, GitHub engaged in a cross-functional analysis (including Policy, Legal, Procurement, Finance, and Operations, especially Human Resources) to determine where labor services exist in its business and supply chain and to identify potential risks related to modern slavery and child labor. GitHub prioritizes areas where those risks might be more significant in terms of severity, scale, or probability for greater due diligence, monitoring, and verification. GitHub continues to consider where risks may occur and how to address them. In addition, GitHub now obtains its suppliers' assurance that they have practices consistent with this Statement, including by complying with laws related to modern slavery or child labor.
+
+### Places in GitHub's business and supply chains where there is a risk of modern slavery and child labor, and steps GitHub has taken to assess and manage that risk
+
+GitHub has not identified any high-risk suppliers; however, modern slavery or child labor would be more likely to occur with suppliers for services involving manual labor, such as event support, construction, facilities services, and food services. GitHub will audit its existing suppliers and require those in such higher risk areas to confirm that they provide services consistent with this Statement.
+
+Although GitHub knows of no actual or alleged modern slavery or child labor in its business or supply chain, and has no credible basis to believe it is occurring, GitHub is committed to providing remedies if GitHub itself were to directly cause modern slavery or child labor and to remediation of broader patterns of non-conformance with this Statement caused by deficiencies in GitHub's systems or processes. GitHub's remediation to individual victims would include protocols for appropriate immediate action to eliminate the modern slavery and child labor practices, along with resources for reasonable and appropriate victim services designed to offset the harm experienced.
+
+### Effectiveness in ensuring neither modern slavery nor child labor is occurring in GitHub's business or supply chains
+
+GitHub complies and will continue to comply with laws related to modern slavery and child labor.
+
+Going forward, GitHub now requires its suppliers to comply with this Statement, as well as laws related to modern slavery and child labor. GitHub now also requires its suppliers to:
+   - not use, participate in, support, or tolerate modern slavery or child labor
+   - not use misleading or fraudulent recruitment or engagement practices for employees or contract workers
+   - not charge employees or contract workers recruitment or engagement fees
+   - not destroy, conceal, confiscate, or otherwise deny access by an employee or any contract worker to passport, driver's license, or other identity documents;
+   - allow us to terminate our agreements with them for any violation of its obligations related to modern slavery or child labor; and
+   - remediate any harms caused to any worker found to be subjected to any form of modern slavery or child labor, if required by law.
+
+In addition, GitHub strongly encourages its suppliers to:
+   - conduct anti-modern slavery and child labor due diligence processes, including risk assessments, for their suppliers;
+   - take steps to address risks identified; and
+   - use similar anti-modern slavery and child labor language with their suppliers.
+
+GitHub's procurement instructions to employees making company purchases now includes a reference to the requirement for suppliers to comply with this Statement.
+
+### Training for GitHub staff about modern slavery and human trafficking
+
+GitHub is developing modern slavery and child labor training that will be mandatory for all employees, with a view to GitHub's business and supply chain. GitHub will emphasize suppliers providing services involving manual labor, such as event support, construction, facilities services, and food services, as areas of greater potential risk.
+
+**GitHub's Board of Directors approved [this Statement](/assets/images/help/site-policy/github-statement-against-modern-slavery-and-child-labor.pdf).**


### PR DESCRIPTION
We are adding GitHub's 2018 Statement Against Modern Slavery and Child Labor to our open-sourced policies. We update this statement each year, and submit it to our Board of Directors for approval. So we won't make any changes to this document in this cycle, but we'll consider comments or feedback in our preparation of the 2019 statement.