### PR TITLE
Update to the GitHub Subprocessors and Cookies policy - Winter 2019

### DIFF
--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -83,7 +83,7 @@ We use Google Analytics as a third party analytics service, and to track our adv
 
 #### Pages on GitHub where analytics may be enabled
 
-The following pages and the subdomains of those pages on our main site may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
+Pages at URLs that contain any of the following domains and paths (including any subdomains or subpaths) on our sites may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
 
 - github.com/home (if you are logged out or do not have an account, this is the page you will see when you go to github.com)
 - github.com/about

--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -7,7 +7,7 @@ redirect_from:
  - /github-cookies/
 ---
 
-Effective date: **May 25, 2018**
+Effective date: **April 19, 2019**
 
 GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), how we use [cookies](#cookies-on-github), and where and how we perform any [tracking on GitHub](#tracking-on-github).
 
@@ -17,31 +17,36 @@ When we share your information with third party subprocessors, such as our vendo
 
 | Name of Subprocessor | Description of Processing | Location of Processing |
 |---|---|---|
-| Box | Corporate document storage | United States |
+| Automattic | Blogging service | United States |
+| AWS Amazon | Data hosting | United States |
 | Braintree (PayPal) | Subscription credit card payment processor | United States |
-| DocuSign | Contract signature processor | United States |
-| Dropbox | Corporate document storage | United States |
+| Clearbit | Marketing data enrichment service | United States |
+| DiscoverOrg | Marketing data enrichment service | United States |
+| Eloqua | Marketing campaign automation | United States |
 | Front | Support inbox system | United States |
 | Google Apps | Internal company infrastructure | United States |
 | Google Analytics | Website analytics and performance | United States |
+| LinkedIn Navigator | Marketing data enrichment service | United States |
 | Lithium | Community forum software provider | United States |
+| Magic Robot | Campaign reporting (Salesforce Add-on) | United States |
 | MailChimp | Customer ticketing mail services provider | United States |
 | Mailgun | Transactional mail services provider | United States |
 | Nexmo | SMS notification provider | United States |
 | Oracle | Corporate financial system | United States |
 | Salesforce.com | Customer relations management | United States |
+| Segment | Data analytics platform | United States |
 | Sendgrid | Transactional mail services provider | United States |
 | Twilio | SMS notification provider | United States | 
 | Zendesk | Customer support ticketing system | United States |
 | Zuora | Corporate billing system | United States |
 
-When we bring on a new vendor or other subprocessor who handles our Users' Personal Information, or remove a subprocessor, or we change how we use a subprocessor, we will update this page. If you have questions or concerns about a new subprocessor, we'd be happy to help. Please contact us via {{ site.data.variables.contact.contact_privacy }}.
+When we bring on a new subprocessor who handles our Users' Personal Information, or remove a subprocessor, or we change how we use a subprocessor, we will update this page. If you have questions or concerns about a new subprocessor, we'd be happy to help. Please contact us via {{ site.data.variables.contact.contact_privacy }}.
 
 ### Cookies on GitHub
 
-GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, and provide information for future development of GitHub.
+GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, provide information for future development of GitHub, and to advertise GitHub's products and services to you on third party sites.
 
-A cookie is a small piece of text that our web server stores on your computer or mobile device, which your browser sends to us when you return to our site. Cookies do not necessarily identify you if you are merely visiting GitHub; however, a cookie may store a unique identifier for each logged in user. The cookies GitHub sets are essential for the operation of the website, or are used for performance or functionality. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept cookies, you will not be able to log in or use GitHub’s services.
+A cookie is a small piece of text that our web server stores on your computer or mobile device, which your browser sends to us when you return to our site. Cookies do not necessarily identify you if you are merely visiting GitHub; however, a cookie may store a unique identifier for each logged in user. We use cookies to keep you logged in, remember your preferences, and provide information for future development of GitHub. For security reasons, we use cookies to identify a device. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept these cookies, you will not be able to log in or use GitHub’s services. On certain areas of the website, we may also use cookies to identify you and/or your device to advertise GitHub products and services to you on third party sites.
 
 GitHub sets the following cookies on our users for the following reasons:
 
@@ -59,6 +64,8 @@ GitHub sets the following cookies on our users for the following reasons:
 | `__Host-user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
 | `__Host-gist_user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
 | `_ga` | This cookie is used by Google Analytics. |
+| `_gat` | This cookie is used by Google Analytics. |
+| `_gid` | This cookie is used by Google Analytics. |
 | `_octo` | This cookie is used by Octolytics, our internal analytics service, to distinguish unique users and clients. |
 | `tracker` | This cookie tracks the referring source for signup analytics. |
 
@@ -66,48 +73,34 @@ Certain pages on our site may set other third party cookies. For example, we may
 
 ### Tracking on GitHub
 
-"[Do Not Track](https://www.eff.org/issues/do-not-track)" is a privacy preference you can set in your browser if you do not want online services — specifically ad networks — to collect and share certain kinds of information about your online activity from third party tracking services. GitHub does not currently respond differently to an individual browser's Do Not Track setting. If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://www.eff.org/privacybadger).
+"[Do Not Track](https://www.eff.org/issues/do-not-track)" (DNT) is a privacy preference you can set in your browser if you do not want online services — specifically ad networks — to collect and share certain kinds of information about your online activity from third party tracking services. GitHub responds to browser DNT signals and follows the [W3C standard for responding to DNT signals](https://www.w3.org/TR/tracking-dnt/). If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://www.eff.org/privacybadger).
 
-We do not track your online browsing activity on other online services over time and we do not host third-party advertising on GitHub that might track your activity on our site. We do have agreements with certain vendors, such as analytics providers, who help us track visitors' movements on certain pages on our site. Only our vendors, who are collecting data on our behalf, may collect data on our pages, and we have signed data protection agreements with every vendor who collects this data on our behalf. We use the data we receive from these vendors to better understand our visitors' interests, to understand our website's performance, and to improve our content. Any analytics vendor will be listed in our Subprocessor List above, and you may see a list of every page where we collect this kind of data below.
+If you have not enabled DNT on a browser that supports it, cookies on some parts of our website will track your online browsing activity on other online services over time, though we do not permit third parties other than our analytics and service providers to track GitHub users' activity over time on GitHub. We use these cookies to allow us to advertise GitHub products and services to you on third party websites and services. We also have agreements with certain vendors, such as analytics providers, who help us track visitors' movements on certain pages on our site. Only our vendors, who are collecting personal information on our behalf, may collect data on our pages, and we have signed data protection agreements with every vendor who collects this data on our behalf. We use the data we receive from these vendors to better understand our visitors' interests, to understand our website's performance, and to improve our content. Any analytics vendor will be listed in our Subprocessor List above, and you may see a list of every page where we collect this kind of data below.
 
 #### Google Analytics
 
-We use Google Analytics as a third party analytics service, but we don’t use it for advertising purposes. We use Google Analytics to collect information about how our website performs and how our users, in general, navigate through and use GitHub. This helps us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. Google provides further information about its own privacy practices and [offers a browser add-on to opt out of Google Analytics tracking](https://tools.google.com/dlpage/gaoptout).
+We use Google Analytics as a third party analytics service, and to track our advertising campaigns on third party websites and services. We use Google Analytics to collect information about how our website performs and how our users, in general, navigate through and use GitHub. This helps us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. Google provides further information about its own privacy practices and [offers a browser add-on to opt out of Google Analytics tracking](https://tools.google.com/dlpage/gaoptout).
 
 #### Pages on GitHub where analytics may be enabled
 
-The following pages on our main site may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
+The following pages and the subdomains of those pages on our main site may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
 
 - github.com/home (if you are logged out or do not have an account, this is the page you will see when you go to github.com)
 - github.com/about
-   - github.com/about/careers
-   - github.com/about/press
-- github.com/blog
-- github.com/business
-   - github.com/business/customers
-   - github.com/business/customers/{$customer}
- - github.com/business/security
+- github.blog
+- github.com/enterprise
 - github.com/collections
 - github.com/developer-stories
-   - github.com/developer-stories/{$developer}
 - github.com/events
 - github.com/explore
 - github.com/features
-   - github.com/features/code-review
-   - github.com/features/project-management
-   - github.com/features/integrations
 - github.com/logos
 - github.com/nonprofit
 - github.com/open-source
-   - github.com/open-source/stories
-   - github.com/open-source/stories/{$maintainer}
 - github.com/personal
 - github.com/pricing
-   - github.com/pricing/developer
-   - github.com/pricing/team
-   - github.com/pricing/business-hosted
-   - github.com/pricing/business-enterprise
 - github.com/ten
 - github.com/trending
-- github.com/updates
-   - github.com/updates/satellite-2017
+- resources.github.com
+- de.github.com
+- fr.github.com


### PR DESCRIPTION
This update to the Subprocessors and Cookies policy updates our subprocessor list and our policy with respect to cookie usage on our website, including changes to the following sections:
* GitHub Subprocessors
* Cookies on GitHub
* Tracking on GitHub