### PR TITLE
Update to GitHub and Export Controls policy - Winter 2019

### DIFF
--- a/Policies/github-and-export-controls.md
+++ b/Policies/github-and-export-controls.md
@@ -2,22 +2,26 @@
 title: GitHub and Export Controls
 ---
 
-GitHub.com, GitHub Enterprise, and the information you upload to either product may be subject to US export control laws, including U.S. Export Administration Regulations (the EAR).
+GitHub.com, GitHub Enterprise Server, and the information you upload to either product may be subject to US export control laws, including U.S. Export Administration Regulations (the EAR).
 
-Although we've provided the following information below for your convenience, it is ultimately your responsibility to ensure that your use of GitHub's products and services comply with all applicable laws and regulations, including US export control laws.
+Although we've provided the following information below for your convenience, it is ultimately your responsibility to ensure that your use of GitHub's products and services complies with all applicable laws and regulations, including US export control laws.
 
 ### GitHub.com
 
-GitHub.com, the cloud-hosted service offering available at [github.com](https://github.com) has not been audited for compliance with ITAR or other export controls, and does not currently offer the ability to restrict repository access by country.
+Under our [Terms of Service](articles/github-terms-of-service), users may only access and use GitHub.com in compliance with applicable law, including U.S. export control and sanctions laws.  
 
-If you are looking to collaborate on ITAR- or other export-controlled data, we recommend you consider [GitHub Enterprise](https://enterprise.github.com), GitHub's on-premises offering.
+Users are responsible for ensuring that the content they develop and share on GitHub.com complies with the U.S. export control laws, including the EAR and the U.S. International Traffic in Arms Regulations (ITAR). The cloud-hosted service offering available at [Github.com](https://github.com) has not been audited for compliance with ITAR or other export controls, and does not currently offer the ability to restrict repository access by country. If you are looking to collaborate on ITAR- or other export-controlled data, we recommend you consider [GitHub Enterprise Server](https://enterprise.github.com), GitHub's on-premises offering.
 
-### GitHub Enterprise
+GitHub.com may not be used for purposes prohibited under relevant export control laws, including purposes related to the development, production, or use of nuclear, biological, or chemical weapons or long range missiles or unmanned aerial vehicles. 
 
-GitHub Enterprise is a self-hosted virtual appliance that can be run within your own datacenter or virtual private cloud. As such, GitHub Enterprise can be used to store ITAR- or other export-controlled information, however, end users are responsible for ensuring such compliance.
+GitHub may allow users in or ordinarily resident in jurisdictions subject to U.S. sanctions to access certain GitHub.com services pursuant to authorizations issued by the Office of Foreign Assets Controls (OFAC).  Persons in and residents of these jurisdictions are prohibited from using IP proxies, VPNs, or other methods to disguise their location when accessing GitHub services and may only use GitHub for non-commercial, personal communications.  
 
-GitHub has an Encryption Registration Number (ERN) of `R108186`.
+Specially Designated Nationals (SDNs) and other denied or blocked parties under U.S. and other applicable law are prohibited from accessing or using GitHub.com.  Users may not use GitHub.com for or on behalf of such parties, including the Governments of sanctioned countries.  
 
-GitHub Enterprise is a commercial, mass-market product and has been assigned the Encryption Control Registration Number (ECCN) of `5D992.c` and may be exported to most destinations with no license required (NLR).
+### GitHub Enterprise Server
 
-GitHub Enterprise may not be sold to, exported, or re-exported to any country listed in Country Group E:1 in Supplement No. 1 to part 740 of the EAR. This list currently contains Cuba, Iran, North Korea, Sudan & Syria, but may be subject to change.
+GitHub Enterprise Server is a self-hosted virtual appliance that can be run within your own datacenter or virtual private cloud. As such, GitHub Enterprise Server can be used to store ITAR- or other export-controlled information, however, end users are responsible for ensuring such compliance.
+
+GitHub Enterprise Server is a commercial, mass-market product and has been assigned the Encryption Control Registration Number (ECCN) of `5D992.c` and may be exported to most destinations with no license required (NLR).
+
+GitHub Enterprise Server may not be sold to, exported, or re-exported to any country listed in Country Group E:1 in Supplement No. 1 to part 740 of the EAR or to the Crimea region of Ukraine. This list currently contains Cuba, Iran, North Korea, Sudan & Syria, but is subject to change.


### PR DESCRIPTION
This update to the GitHub and Export Controls policy includes clarifications of existing policies, including changes to the following sections:
* GitHub.com
* Enterprise Server