### PR TITLE
Language improvements to the community guidelines "Building a strong community" section 

### DIFF
--- a/Policies/github-community-guidelines.md
+++ b/Policies/github-community-guidelines.md
@@ -18,13 +18,17 @@ We rely on our community members to communicate expectations, [moderate](#what-i
 The primary purpose of the GitHub community is to collaborate on software projects.
 We want people to work better together. Although we maintain the site, this is a community we build *together*, and we need your help to make it the best it can be.
 
-* **Be welcoming and open-minded** - Other collaborators may not have the same experience level or background as you, but that doesn't mean they don't have good ideas to contribute. We encourage you to be welcoming to new collaborators on your projects and discussions.
+* **Be welcoming and open-minded** - Other collaborators may not have the same experience level or background as you, but that doesn't mean they don't have good ideas to contribute. We encourage you to be welcoming to new collaborators and those just getting started.
 
-* **Assume no malice** - Humans make mistakes, and disagreements or differences of opinion are a fact of life. Try to approach conflict from the perspective that people generally mean well. This will promote a respectful and friendly atmosphere where people feel comfortable asking questions, participating in discussions, and making contributions.
+* **Respect each other.**  Nothing sabotages healthy conversation like rudeness. Be civil and professional, and don’t post anything that a reasonable person would consider offensive, abusive, or hate speech. Don’t harass or grief anyone. Treat each other with dignity and consideration in all interactions.
 
-* **Stay on topic** - People use GitHub to get work done and to be more productive. Off topic comments are a distraction (sometimes welcome, but usually not) from getting work done and being productive. Staying on topic helps produce positive and productive discussions.
+  You may wish to respond to something by disagreeing with it. That’s fine. But remember to criticize ideas, not people. Avoid name-calling, ad hominem attacks, responding to a post’s tone instead of its actual content, and knee-jerk contradiction. Instead, provide reasoned counter-arguments that improve the conversation.
 
-* **Be clear** - Communicating with strangers on the Internet can be awkward. It's hard to convey or read tone, and sarcasm is frequently misunderstood. Try to use clear language, and think about how it will be received by the other person.
+* **Communicate with empathy** - Disagreements or differences of opinion are a fact of life. Being part of a community means interacting with people from a variety of backgrounds and perspectives, many of which may not be your own. If you disagree with someone, try to understand and share their feelings before you address them. This will promote a respectful and friendly atmosphere where people feel comfortable asking questions, participating in discussions, and making contributions.
+
+* **Be clear and stay on topic** - People use GitHub to get work done and to be more productive. Off-topic comments are a distraction (sometimes welcome, but usually not) from getting work done and being productive. Staying on topic helps produce positive and productive discussions.
+
+   Additionally, communicating with strangers on the Internet can be awkward. It's hard to convey or read tone, and sarcasm is frequently misunderstood. Try to use clear language, and think about how it will be received by the other person.
 
 ### What if something or someone offends you?
 


### PR DESCRIPTION
This pull request makes non-substantive language improvements to the "Building a strong community" section of the Community Guidelines. Specifically:

* Changes "assume no malice" to "communicate with empathy"
* Adds a "respect each other" section
* Combines "be clear" and "stay on topic" into a single section for readability

Background: The [GitHub Community Forum Code of Conduct](https://github.community/t5/Welcome/Code-of-Conduct/m-p/65#M37) was originally based on the [GitHub Community Guidelines](https://help.github.com/en/github/site-policy/github-community-guidelines). While adapting the document for use with the Community Forum, we made the language improvements to more accurately communicate the intended policy. This pull request contributes those downstream improvements back to the original document.