### PR TITLE
Remove/replace deprecated support email with contact form link

### DIFF
--- a/Policies/github-sensitive-data-removal-policy.md
+++ b/Policies/github-sensitive-data-removal-policy.md
@@ -75,7 +75,7 @@ These guidelines are designed to make the processing of requests to remove sensi
 
 ### How to Submit Your Request
 
-You can email your request to remove sensitive data to <a href="mailto:support@github.com" data-proofer-ignore>support&#64;github.com</a> or submit your request via our [Contact form](https://github.com/contact/). Please include a plain-text version of your request in the body of your message. Sending your request in an attachment may result in processing delays.
+You can submit your request to remove sensitive data via our [contact form](https://support.github.com/contact). Please include a plain-text version of your request in the body of your message. Sending your request in an attachment may result in processing delays.
 
 ### Disputes
 

--- a/Policies/github-trademark-policy.md
+++ b/Policies/github-trademark-policy.md
@@ -22,7 +22,7 @@ When we receive reports of trademark policy violations from holders of federal o
 
 ### How Do I Report a Trademark Policy Violation?
 
-Holders of registered trademarks can report possible trademark policy violations to GitHub via email to <a href="mailto:support@github.com" data-proofer-ignore>support&#64;github.com</a>. Please submit trademark-related requests from your company email address and include all the information requested below to help expedite our response. Also be sure to clearly describe to us why the account may cause confusion with your mark or how the account may dilute or tarnish your mark.
+Holders of registered trademarks can report possible trademark policy violations to GitHub via our [contact form](https://support.github.com/contact). Please submit trademark-related requests from your company email address and include all the information requested below to help expedite our response. Also be sure to clearly describe to us why the account may cause confusion with your mark or how the account may dilute or tarnish your mark.
 
 ### What Information is Required When Reporting Trademark Policy Violations?
 

--- a/Policies/githubs-notice-about-the-california-consumer-privacy-act.md
+++ b/Policies/githubs-notice-about-the-california-consumer-privacy-act.md
@@ -18,7 +18,7 @@ GitHub _does not_ sell personal information, including personal information of a
 
 ## Your rights under the CCPA
 
-The CCPA provides California residents with certain rights related to their personal information. To submit a request based on these rights, please contact us at support@github.com.
+The CCPA provides California residents with certain rights related to their personal information. To submit a request based on these rights, please contact us via our [contact form](https://support.github.com/contact).
 
 When receiving a request, we will verify that the individual making the request is the resident to whom the personal information subject to the request pertains. California residents may exercise their rights themselves or may use an authorized agent to make requests to disclose certain information about the processing of their personal information or to delete personal information on their behalf. If you use an authorized agent to submit a request, we may require that you provide us additional information demonstrating that the agent is acting on your behalf.
 
@@ -73,4 +73,4 @@ The CCPA provides exemptions, until and including December 31, 2020, from certai
 
   personal information reflecting a written or verbal communication or a transaction between GitHub and a natural person, where the natural person is acting as an employee, owner, director, officer, or contractor of a company, partnership, sole proprietorship, nonprofit, or government agency and whose communications or transaction with GitHub occur solely within the context of GitHub conducting due diligence regarding, or providing or receiving a product or service to or from such company, partnership, sole proprietorship, nonprofit or government agency.
 
-If you have any questions about this page, please contact us at support@github.com.
+If you have any questions about this page, please contact us via our [contact form](https://support.github.com/contact).


### PR DESCRIPTION
removing mentions of deprecated email with contact form link in 
- Sensitive Data Removal Policy
- Trademark Policy
- Notice About the California Consumer Privacy Act