### PR TITLE
add option for vendors to comply with Microsoft's Supplier CoC or GitHub's statement

### DIFF
--- a/Policies/github-anti-bribery-statement.md
+++ b/Policies/github-anti-bribery-statement.md
@@ -51,4 +51,4 @@ While the U.S. FCPA is focused on interactions with government officials, the U.
 
 ### Engaging our Partners
 - GitHub’s standard **resale agreements with Channel Partners** include mandatory anti-corruption clauses. Going forward, GitHub now requires our Channel Partners to commit to complying with this Anti-Corruption Statement.
-- Going forward, GitHub’s **vendor contracts** now require a commitment to comply with this Anti-Corruption Statement.
+- Going forward, GitHub’s **vendor contracts** now require a commitment to comply with Microsoft's Supplier Code of Conduct or this Anti-Corruption Statement.

--- a/Policies/github-statement-against-modern-slavery-and-child-labor.md
+++ b/Policies/github-statement-against-modern-slavery-and-child-labor.md
@@ -97,7 +97,7 @@ In addition, GitHub strongly encourages its suppliers to:
    - take steps to address risks identified; and
    - use similar anti-modern slavery and child labor language with their suppliers.
 
-GitHub's procurement instructions to employees making company purchases now includes a reference to the requirement for suppliers to comply with this Statement.
+GitHub's procurement instructions to employees making company purchases now includes a reference to the requirement for suppliers to comply with Microsoft's Supplier Code of Conduct or this Statement.
 
 ### Training for GitHub staff about modern slavery and human trafficking
 


### PR DESCRIPTION
updating our anti-bribery and anti-slavery statements so that vendors must comply with either Microsoft's Supplier Code of Conduct or GitHub's anti-bribery and anti-slavery statements