### PR TITLE
Add deceased user policy

### DIFF
--- a/Policies/github-community-guidelines.md
+++ b/Policies/github-community-guidelines.md
@@ -11,7 +11,7 @@ Millions of developers host millions of projects on GitHub — both open and clo
 
 GitHub users worldwide bring wildly different perspectives, ideas, and experiences, and range from people who created their first "Hello World" project last week to the most well-known software developers in the world. We are committed to making GitHub a welcoming environment for all the different voices and perspectives in our community, while maintaining a space where people are free to express themselves.
 
-We rely on our community members to communicate expectations, [moderate](#what-if-something-or-someone-offends-you) their projects, and [report](https://github.com/contact/report-abuse) abusive behavior or content. We do not actively seek out content to moderate. By outlining what we expect to see within our community, we hope to help you understand how best to collaborate on GitHub, and what type of actions or content may violate our [Terms of Service](#legal-notices). We will investigate any abuse reports and may moderate public content on our site that we determine to be in violation of our Terms of Service.
+We rely on our community members to communicate expectations, [moderate](#what-if-something-or-someone-offends-you) their projects, and {{ site.data.variables.contact.report_abuse }} or {{ site.data.variables.contact.report_content }}. We do not actively seek out content to moderate. By outlining what we expect to see within our community, we hope to help you understand how best to collaborate on GitHub, and what type of actions or content may violate our [Terms of Service](#legal-notices). We will investigate any abuse reports and may moderate public content on our site that we determine to be in violation of our Terms of Service.
 
 ### Building a strong community
 
@@ -42,7 +42,7 @@ We rely on the community to let us know when an issue needs to be addressed. We 
 
 * **Block Users**  - If you encounter a user who continues to demonstrate poor behavior, you can [block the user from your personal account](/articles/blocking-a-user-from-your-personal-account/) or [block the user from your organization](/articles/blocking-a-user-from-your-organization/).
 
-Of course, you can always contact us to [**Report Abuse**](https://github.com/contact/report-abuse) if you need more help dealing with a situation.
+Of course, you can always contact us to {{ site.data.variables.contact.report_abuse }} if you need more help dealing with a situation.
 
 ### What is not allowed?
 

--- a/Policies/github-deceased-user-policy.md
+++ b/Policies/github-deceased-user-policy.md
@@ -1,0 +1,21 @@
+---
+title: GitHub Deceased User Policy
+productVersions:
+  dotcom: '*'
+---
+
+In the event that a GitHub user passes away, we can work with an authorized individual to determine what happens to the account's content. 
+
+If you are next of kin, a [pre-designated successor](/github/setting-up-and-managing-your-github-user-account/maintaining-ownership-continuity-of-your-user-accounts-repositories), or other authorized individual (which could include a collaborator or business partner) of a deceased user and would like to make a request regarding their account, you can reach out to us at https://support.github.com/contact. Please provide the following information in your message:
+
+- Name
+- Contact Information
+- Name of the deceased account holder
+- GitHub username of the deceased account holder
+- Your relationship to the deceased account holder (please include whether you have been designated as the account successor on GitHub.com)
+- If designated as account successor, the username of your GitHub account
+- What action you are seeking (e.g. transfer public repositories, cancel billing on account)
+
+Once we have received your request, we may follow up with a request for additional information, such as a copy of your photo identification, copy of the death certificate, and documentation confirming you are authorized to act in relation to the deceased user’s account, to verify that we are properly authorized to process your request. 
+
+Please note, the information you provide in your request is collected in accordance with our [Privacy Statement](/github/site-policy/github-privacy-statement), and we will retain the information only as necessary to comply with our legal obligations and resolve disputes.

--- a/Policies/github-sensitive-data-removal-policy.md
+++ b/Policies/github-sensitive-data-removal-policy.md
@@ -24,7 +24,7 @@ For the purposes of this document, “sensitive data” refers to content that (
 - Mere mentions of your company's identity, name, brand, domain name, or other references to your company in files on GitHub. You must be able to articulate why a use of your company's identity is a threat to your company's security posture before we will take action under this policy.
 - Privacy complaints. If you have concerns about your own privacy or you are contacting us on behalf of your employees due to a privacy concern — for example, if there are private email addresses or other personal information posted — please contact us via [our Privacy contact form](https://github.com/contact/privacy).
 - Entire files or repositories that do not pose a specific security risk, but you believe are otherwise objectionable.
-- Content governed by our [Community Guidelines](/articles/github-community-guidelines/), such as malware or general-purpose tools. If you have questions about our Community Guidelines or believe that content on GitHub might violate our guidelines, you can [report that content here](https://github.com/contact/report-content).
+- Content governed by our [Community Guidelines](/articles/github-community-guidelines/), such as malware or general-purpose tools. If you have questions about our Community Guidelines or believe that content on GitHub might violate our guidelines, you can use {{ site.data.variables.contact.report_content }} to contact us.
 
 ### Things to Know
 


### PR DESCRIPTION
This PR adds a new file to explain how an authorized individual of a deceased GitHub user can contact us regarding the deceased user account's content. 