### PR TITLE
update CONTRIBUTING and README to reflect quicker ships

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,13 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ## Getting Started
 
-As we mentioned in the README, we're mostly looking for contributions to a few of our policies, which are listed below. However, just because a policy is on the list, it does not mean that the terms are flexible. The current Terms of Service can found on our website, at https://docs.github.com/en/github/site-policy/github-terms-of-service, and all Users must agree to them before using our website. We've opened this repo to provide more transparency around the updates to those Terms of Service, to allow you all to help us improve them, and to do so the GitHub way. Here are the policies we're currently hoping you'll contribute to:
+As we mentioned in the README, we're mostly looking for contributions to a few of our policies, which are listed below. However, just because a policy is on the list, it does not mean that the terms are flexible. The current Terms of Service can found on our website, at https://docs.github.com/github/site-policy/github-terms-of-service, and all Users must agree to them before using our website. We've opened this repo to provide more transparency around the updates to those Terms of Service, to allow you all to help us improve them, and to do so the GitHub way. Here are the policies we're currently hoping you'll contribute to:
 
-* [GitHub Terms of Service](https://docs.github.com/en/github/site-policy/github-terms-of-service)
-* [GitHub Privacy Statement](https://docs.github.com/en/github/site-policy/github-privacy-statement)
-* [GitHub Global Privacy Practices](https://docs.github.com/en/github/site-policy/global-privacy-practices)
+* [GitHub Terms of Service](https://docs.github.com/github/site-policy/github-terms-of-service)
+* [GitHub Acceptable Use Policies](https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-acceptable-use-policies)
+* [GitHub Community Guidelines](https://docs.github.com/en/github/site-policy/github-community-guidelines)
+* [GitHub Privacy Statement](https://docs.github.com/github/site-policy/github-privacy-statement)
+* [GitHub Global Privacy Practices](https://docs.github.com/github/site-policy/global-privacy-practices)
 
 
 Like other repos, the two main ways to contribute are through Issues and Pull Requests. Feel free to use either option, whichever you prefer. We've made an issue template to request information that will help us better understand your feedback.
@@ -32,14 +34,14 @@ Before you decide to open an issue, browse [open issues](https://github.com/gith
 
 **NOTE:** Issues are best used as a task list, where each issue contains one and only one thing to be addressed, resolved, fixed or decided. So please include only one work item per issue. This helps us know when issues are completed and can be closed. In turn, this helps everyone watching the issues know when the item they're interested in has been resolved.
 
-If you decide to open a pull request to the master branch, please be aware that it is unlikely that we will merge it directly. It's not because we don't like your ideas, but because we will be opening new draft branches with each round of changes.
+If you decide to open a pull request to the main branch, please be aware that it is unlikely that we will merge it directly unless it is a typo correction. It's not because we don't like your ideas, but because we may need to iterate on them internally, and officially open a pull request with the amount of notice appropriate for the policy in question.
 
-In general, before we make official changes to our site policies, we will open a pull request in this repository, showing all the draft changes on a working branch. In that pull request, we will do our best to cross link back to open issues or pull requests that we think are resolved or addressed by the draft changes. When those draft changes are ready to be published, we will make them on the official live version at https://docs.github.com/en/github/site-policy. After that, we'll merge the working branch in this repository.
+In general, before we make official changes to our site policies, we will open a pull request in this repository, showing all the draft changes on a working branch. In that pull request, we will do our best to cross link back to open issues or pull requests that we think are resolved or addressed by the draft changes. When those draft changes are ready to be published, we will make them on the official live version at https://docs.github.com/github/site-policy. After that, we'll merge the working branch in this repository.
 
 **NOTE:** Please don't post legal complaints or ask for technical support in this repository. We may not respond to issues or comments promptly. If you need help, [contact Support](https://github.com/contact) and they'll get you an answer.
 
 ## Resources
 
 - [Contributing to Open Source on GitHub](https://opensource.guide/how-to-contribute/)
-- [Using Pull Requests](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
-- [GitHub Docs](https://docs.github.com/en)
+- [Using Pull Requests](https://docs.github.com/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+- [GitHub Docs](https://docs.github.com)

--- a/README.md
+++ b/README.md
@@ -25,15 +25,13 @@ That's easy: just be responsible. Follow our [Code of Conduct](CODE_OF_CONDUCT.m
 
 ### How often will GitHub review these policies?
 
-We have a semi-annual review and modification process for the policies in this repository. This allows plenty of time for discussion and lets our community rely on our policies. Of course, GitHub may alter our policies outside that schedule if necessary, such as when we have new product releases.
+We continually review and modify the policies in this repository. Our review and modification process allows for discussion about upcoming changes before they go into effect and lets our community rely on our policies. Of course, GitHub may alter our policies outside that schedule if necessary, such as when we have new product releases.
 
-#### What's the process?
+#### What's the process? 
 
-Policies will be open for discussion and feedback throughout the year. You can expect that someone from GitHub's legal department will see your feedback, but we might not respond immediately. If you need an immediate answer on a legal matter, [contact Support](https://github.com/contact).
+Policies will be open for [discussion and feedback](CONTRIBUTING.md) throughout the year. You can expect that someone from GitHub's legal department will see your feedback, but we might not respond immediately. If you need an immediate answer on a legal matter, [contact Support](https://github.com/contact).
 
-Every six months, we'll do thorough review of the feedback we have received. If changes are not needed, great! We'll let you know that we're not putting out an update, and we'll close any issues or PRs that are still hanging around.
-
-If changes to a policy _are_ needed, we will freeze feedback for two weeks. We'll draft changes based on the pull requests and input we've gotten. Then we'll post the updated policy as a pull request, and we'll get your feedback on the pull request. The updated policy will be available here for thirty days before it goes into effect.
+When _we_ open a pull request, in most cases, we'll leave it open for 24 hours before the changes go into effect. Comments on and review of our pull requests are welcome, just like in any open source project. For material changes to our [Privacy Statement](/github/site-policy/github-privacy-statement) or [Terms of Service](/github/site-policy/github-terms-of-service#q-changes-to-these-terms) (including our Acceptable Use Policies), we'll post the updates 30 days before they go into effect, as stated in those docs. (We had previously applied a 30-day comment period for most docs in this repo but found that we tend to get feedback soon after we post the changes and were unnecessarily delaying ships.)
 
 For those who are following this repository, the posting of the updated policy will provide a notice of any modifications to the policy. Please note, links will not resolve in the rendering of the policies in this repository.
 


### PR DESCRIPTION
updating CONTRIBUTING and README - tl;dr of the changes and reason (quoting what the revised README will say) 👇 

>When _we_ open a pull request, in most cases, we'll leave it open for 24 hours before the changes go into effect. Comments on and review of our pull requests are welcome, just like in any open source project. For material changes to our [Privacy Statement](/github/site-policy/github-privacy-statement) or [Terms of Service](/github/site-policy/github-terms-of-service#q-changes-to-these-terms) (including our Acceptable Use Policies), we'll post the updates 30 days before they go into effect, as stated in those docs. (We had previously applied a 30-day comment period for most docs in this repo but found that we tend to get feedback soon after we post the changes and were unnecessarily delaying ships.)