### PR TITLE
Make article available for GitHub Enterprise Server users only

### DIFF
--- a/Policies/github-insights-and-data-protection-for-your-organization.md
+++ b/Policies/github-insights-and-data-protection-for-your-organization.md
@@ -5,7 +5,6 @@ product: '{% data reusables.gated-features.github-insights %}'
 redirect_from:
   - /github/installing-and-configuring-github-insights/github-insights-and-data-protection-for-your-organization
 versions:
-  free-pro-team: '*'
   enterprise-server: '*'
 ---
 


### PR DESCRIPTION
The GitHub Insights feature is available only to GitHub Enterprise Server users. Consequently, some of the links in this policy are to articles that are not available when users view the "Free, pro, team" version of docs.github.com. This results in broken links - as reported by an open source contributor: [Fix broken url in docs](https://github.com/github/docs/pull/637).

I think that the best solution is to show this policy article only when users are browsing the help for GitHub Enterprise Server, which will ensure that all the current (and any future) links work correctly.