### PR TITLE
Cookie update

### DIFF
--- a/Policies/github-privacy-statement.md
+++ b/Policies/github-privacy-statement.md
@@ -11,7 +11,7 @@ versions:
   free-pro-team: '*'
 ---
 
-Effective date: November 16, 2020
+Effective date: December 19, 2020
 
 Thanks for entrusting GitHub Inc. (“GitHub”, “we”) with your source code, your projects, and your personal information. Holding on to your private information is a serious responsibility, and we want you to know how we're handling it.
 
@@ -144,7 +144,7 @@ For more information about our disclosure in response to legal requests, see our
 We may share User Personal Information if we are involved in a merger, sale, or acquisition of corporate entities or business units. If any such change of ownership happens, we will ensure that it is under terms that preserve the confidentiality of User Personal Information, and we will notify you on our Website or by email before any transfer of your User Personal Information. The organization receiving any User Personal Information will have to honor any promises we made in our Privacy Statement or Terms of Service.
 
 #### Aggregate, non-personally identifying information
-We share certain aggregated, non-personally identifying information with others about how our users, collectively, use GitHub, or how our users respond to our other offerings, such as our conferences or events. For example, [we may compile statistics on the open source activity across GitHub](https://octoverse.github.com/).
+We share certain aggregated, non-personally identifying information with others about how our users, collectively, use GitHub, or how our users respond to our other offerings, such as our conferences or events. 
 
 We **do not** sell your User Personal Information for monetary or other consideration.
 
@@ -235,15 +235,13 @@ That said, the email address you have supplied [via your Git commit settings](/g
 
 #### Cookies
 
-GitHub uses cookies and similar technologies (e.g., HTML5 localStorage) to make interactions with our service easy and meaningful. Cookies are small text files that websites often store on computer hard drives or mobile devices of visitors. We use cookies and similar technologies (hereafter collectively "cookies") to provide you our services, for example, to keep you logged in, remember your preferences, identify your device for security purposes, and provide information for future development of GitHub. By using our Website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept these cookies, you will not be able to log in or use GitHub’s services.
+GitHub only uses cookies and similar technologies (e.g., HTML5 localStorage) necessary to make interactions with our service easy and meaningful. Cookies are small text files that websites often store on computer hard drives or mobile devices of visitors. We use cookies and similar technologies (hereafter collectively, "cookies") necessary to provide and secure our service, for example, to keep you logged in, remember your preferences, identify your device for security purposes, and provide information for future development of GitHub. We also use our own cookies to help us analyze our Users' use of GitHub, complie statistical reports on activity, and improve our content and performance. By using our service, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept these cookies, you will not be able to log in or use GitHub’s services.
 
-We provide more information about [cookies on GitHub](/github/site-policy/github-subprocessors-and-cookies#cookies-on-github) on our [GitHub Subprocessors and Cookies](/github/site-policy/github-subprocessors-and-cookies) page that describes the cookies we set, the needs we have for those cookies, and the expiration of such cookies. It also lists our third-party analytics providers and how you can control your cookie preference settings for such cookies.
+We provide more information about [cookies on GitHub](/github/site-policy/github-subprocessors-and-cookies#cookies-on-github) on our [GitHub Subprocessors and Cookies](/github/site-policy/github-subprocessors-and-cookies) page that describes the cookies we set, the needs we have for those cookies, and the expiration of such cookies. 
 
-#### Tracking and analytics
+#### DNT
 
-We use a number of third-party analytics and service providers to help us evaluate our Users' use of GitHub, compile statistical reports on activity, and improve our content and Website performance. We only use these third-party analytics providers on certain areas of our Website, and all of them have signed data protection agreements with us that limit the type of User Personal Information they can collect and the purpose for which they can process the information. In addition, we use our own internal analytics software to provide features and improve our content and performance.
-
-Some browsers have incorporated "Do Not Track" (DNT) features that can send a signal to the websites you visit indicating you do not wish to be tracked. GitHub responds to browser DNT signals and follows the [W3C standard for responding to DNT signals](https://www.w3.org/TR/tracking-dnt/). If you have not enabled DNT on a browser that supports it, cookies on some parts of our Website will track your online browsing activity on other online services over time, though we do not permit third parties other than our analytics and service providers to track GitHub Users' activity over time on GitHub. You can read more about DNT in our [Tracking on GitHub](/github/site-policy/github-subprocessors-and-cookies#tracking-on-github) section of our [GitHub Subprocessors and Cookies](/github/site-policy/github-subprocessors-and-cookies) page.
+"[Do Not Track](https://www.eff.org/issues/do-not-track)" (DNT) is a privacy preference you can set in your browser if you do not want online services to collect and share certain kinds of information about your online activity from third party tracking services. GitHub responds to browser DNT signals and follows the [W3C standard for responding to DNT signals](https://www.w3.org/TR/tracking-dnt/). If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://privacybadger.org/).
 
 ### How GitHub secures your information
 
@@ -316,7 +314,7 @@ In the unlikely event that a dispute arises between you and GitHub regarding our
 
 ### Changes to our Privacy Statement
 
-Although most changes are likely to be minor, GitHub may change our Privacy Statement from time to time. We will provide notification to Users of material changes to this Privacy Statement through our Website at least 30 days prior to the change taking effect by posting a notice on our home page or sending email to the primary email address specified in your GitHub account. We will also update our [Site Policy repository](https://github.com/github/site-policy/), which tracks all changes to this policy. For other changes to this Privacy Statement, we encourage Users to [watch](/github/managing-subscriptions-and-notifications-on-github/viewing-your-subscriptions#configuring-your-watch-settings-for-an-individual-repository) or to check our Site Policy repository frequently.
+Although most changes are likely to be minor, GitHub may change our Privacy Statement from time to time. We will provide notification to Users of material changes to this Privacy Statement through our Website at least 30 days prior to the change taking effect by posting a notice on our home page or sending email to the primary email address specified in your GitHub account. We will also update our [Site Policy repository](https://github.com/github/site-policy/), which tracks all changes to this policy. For other changes to this Privacy Statement, we encourage Users to [watch](/github/managing-subscriptions-and-notifications-on-github/viewing-your-subscriptions#configuring-your-watch-settings-for-an-individual-repository) or to check our Site Policy repository frequently. 
 
 ### License
 

--- a/Policies/github-privacy-statement.md
+++ b/Policies/github-privacy-statement.md
@@ -28,14 +28,14 @@ Of course, the short version and the Summary below don't tell you everything, so
 
 | Section | What can you find there? |
 |---|---|
-| [What information GitHub collects](#what-information-github-collects) | GitHub collects information directly from you for your registration, payment, transactions, and user profile. We also automatically collect from you your usage information, cookies and similar technologies, and device information, subject, where necessary, to your consent. GitHub may also collect User Personal Information from third parties. We only collect the minimum amount of personal information necessary from you, unless you choose to provide more. |
+| [What information GitHub collects](#what-information-github-collects) | GitHub collects information directly from you for your registration, payment, transactions, and user profile. We also automatically collect from you your usage information, cookies, and device information, subject, where necessary, to your consent. GitHub may also collect User Personal Information from third parties. We only collect the minimum amount of personal information necessary from you, unless you choose to provide more. |
 | [What information GitHub does _not_ collect](#what-information-github-does-not-collect) | We don’t knowingly collect information from children under 13, and we don’t collect [Sensitive Personal Information](https://gdpr-info.eu/art-9-gdpr/). |
 | [How GitHub uses your information](#how-github-uses-your-information) | In this section, we describe the ways in which we use your information, including to provide you the Service, to communicate with you, for security and compliance purposes, and to improve our Service. We also describe the legal basis upon which we process your information, where legally required. |
 | [How we share the information we collect](#how-we-share-the-information-we-collect) | We may share your information with third parties under one of the following circumstances: with your consent, with our service providers, for security purposes, to comply with our legal obligations, or when there is a change of control or sale of corporate entities or business units. We do not sell your personal information and we do not host advertising on GitHub. You can see a list of the service providers that access your information. |
 | [Other important information](#other-important-information) | We provide additional information specific to repository contents, public information, and Organizations on GitHub. |
 | [Additional services](#additional-services) | We provide information about additional service offerings, including third-party applications, GitHub Pages, and GitHub applications. |
 | [How you can access and control the information we collect](#how-you-can-access-and-control-the-information-we-collect) | We provide ways for you to access, alter, or delete your personal information. |
-| [Our use of cookies and tracking](#our-use-of-cookies-and-tracking) | We use cookies for the overall functionality of our Website, and we use a small number of tracking and analytics services on a few parts of our site. We offer a page that makes this very transparent. Please see this section for more information. |
+| [Our use of cookies and tracking](#our-use-of-cookies-and-tracking) | We only use strictly necessary cookies to provide, secure and improve our service. We offer a page that makes this very transparent. Please see this section for more information. |
 | [How GitHub secures your information](#how-github-secures-your-information) | We take all measures reasonably necessary to protect the confidentiality, integrity, and availability of your personal information on GitHub and to protect the resilience of our servers. |
 | [GitHub's global privacy practices](#githubs-global-privacy-practices) | We provide the same high standard of privacy protection to all our users around the world. |
 | [How we communicate with you](#how-we-communicate-with-you) | We communicate with you by email. You can control the way we contact you in your account settings, or by contacting us. |
@@ -74,8 +74,8 @@ If you have a paid Account with us, sell an application listed on [GitHub Market
 ##### Usage information
 If you're accessing our Service or Website, we automatically collect the same basic information that most services collect, subject, where necessary, to your consent. This includes information about how you use the Service, such as the pages you view, the referring site, your IP address and session information, and the date and time of each request. This is information we collect from every visitor to the Website, whether they have an Account or not. This information may include User Personal information.
 
-##### Cookies and similar technologies information
-As further described below, and subject, where applicable, to your consent, we automatically collect information from cookies and similar technologies (such as cookie ID and settings) to keep you logged in, to remember your preferences, and to identify you and your device.
+##### Cookies 
+As further described below, we automatically collect information from cookies (such as cookie ID and settings) to keep you logged in, to remember your preferences, to identify you and your device and to analyze your use of our service.
 
 ##### Device information
 We may collect certain information about your device, such as its IP address, browser or client application information, language preference, operating system and application version, device type and ID, and device model and manufacturer. This information may include User Personal information.
@@ -235,7 +235,11 @@ That said, the email address you have supplied [via your Git commit settings](/g
 
 #### Cookies
 
-GitHub only uses cookies and similar technologies (e.g., HTML5 localStorage) necessary to make interactions with our service easy and meaningful. Cookies are small text files that websites often store on computer hard drives or mobile devices of visitors. We use cookies and similar technologies (hereafter collectively, "cookies") necessary to provide and secure our service, for example, to keep you logged in, remember your preferences, identify your device for security purposes, and provide information for future development of GitHub. We also use our own cookies to help us analyze our Users' use of GitHub, complie statistical reports on activity, and improve our content and performance. By using our service, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept these cookies, you will not be able to log in or use GitHub’s services.
+GitHub only uses strictly necessary cookies. Cookies are small text files that websites often store on computer hard drives or mobile devices of visitors. 
+
+We use cookies solely to provide, secure, and improve our service. For example, we use them to keep you logged in, remember your preferences, identify your device for security purposes, analyze your use of our service, compile statistical reports, and provide information for future development of GitHub. We use our own cookies for analytics purposes, but do not use any third-party analytics service providers. 
+
+By using our service, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept these cookies, you will not be able to log in or use our service.
 
 We provide more information about [cookies on GitHub](/github/site-policy/github-subprocessors-and-cookies#cookies-on-github) on our [GitHub Subprocessors and Cookies](/github/site-policy/github-subprocessors-and-cookies) page that describes the cookies we set, the needs we have for those cookies, and the expiration of such cookies. 
 

--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -10,7 +10,7 @@ versions:
   free-pro-team: '*'
 ---
 
-Effective date: **September 25, 2020**
+Effective date: **December 19, 2020**
 
 GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), how we use [cookies](#cookies-on-github), and where and how we perform any [tracking on GitHub](#tracking-on-github).
 
@@ -19,7 +19,7 @@ GitHub provides a great deal of transparency regarding how we use your data, how
 When we share your information with third party subprocessors, such as our vendors and service providers, we remain responsible for it. We work very hard to maintain your trust when we bring on new vendors, and we require all vendors to enter into data protection agreements with us that restrict their processing of Users' Personal Information (as defined in the [Privacy Statement](/articles/github-privacy-statement/)).
 
 | Name of Subprocessor | Description of Processing | Location of Processing | Corporate Location
-|---|---|---|---|
+|:---|:---|:---|:---|
 | Automattic | Blogging service | United States | United States |
 | AWS Amazon | Data hosting | United States | United States |
 | Braintree (PayPal) | Subscription credit card payment processor | United States | United States |
@@ -28,7 +28,7 @@ When we share your information with third party subprocessors, such as our vendo
 | DiscoverOrg | Marketing data enrichment service | United States | United States |
 | Eloqua | Marketing campaign automation | United States | United States |
 | Google Apps | Internal company infrastructure | United States | United States |
-| Google Analytics | Website analytics and performance | United States | United States |
+| Google Analytics | Analytics and performance | United States | United States |
 | LinkedIn Navigator | Marketing data enrichment service | United States | United States |
 | Magic Robot | Campaign reporting (Salesforce Add-on) | United States | United States |
 | MailChimp | Customer ticketing mail services provider | United States | United States |
@@ -49,63 +49,35 @@ When we bring on a new subprocessor who handles our Users' Personal Information,
 
 ### Cookies on GitHub
 
-GitHub uses cookies to make interactions with our service easy and meaningful. We use cookies (and similar technologies, like HTML5 localStorage) to keep you logged in, remember your preferences, and provide information for future development of GitHub.
+GitHub uses cookies and similar technologies (collectively, “cookies”) to provide and secure our websites, as well as to analyze the usage of our websites, in order to offer you a great user experience. Please take a look at our [Privacy Statement](/github/site-policy/github-privacy-statement#our-use-of-cookies-and-tracking) if you’d like more information about cookies, and on how and why we use them. 
+ 
+Since the number and names of cookies may change,the table below may be updated from time to time.
 
-A cookie is a small piece of text that our web server stores on your computer or mobile device, which your browser sends to us when you return to our site. Cookies do not necessarily identify you if you are merely visiting GitHub; however, a cookie may store a unique identifier for each logged-in user. We use cookies to keep you logged in, remember your preferences, and provide information for future development of GitHub. For security reasons, we use cookies to identify a device. By using our website, you agree that we can place these types of cookies on your computer or device. If you disable your browser or device’s ability to accept these cookies, you will not be able to log in or use GitHub’s services. 
+| Service Provider | Cookie Name | Description | Expiration* |
+|:---|:---|:---|:---|
+| GitHub | `app_manifest_token` | This cookie is used during the App Manifest flow to maintain the state of the flow during the redirect to fetch a user session. | five minutes |
+| GitHub | `_device_id` | This cookie is used to track recognized devices for security purposes. | one year |
+| GitHub | `dotcom_user` | This cookie is used to signal to us that the user is already logged in. | one year |
+| GitHub | `_gh_ent` | This cookie is used for temporary application and framework state between pages like what step the customer is on in a multiple step form. | two weeks | 
+| GitHub | `_gh_sess` | This cookie is used for temporary application and framework state between pages like what step the user is on in a multiple step form. | session |
+| GitHub | `gist_oauth_csrf` | This cookie is set by Gist to ensure the user that started the oauth flow is the same user that completes it. | deleted when oauth state is validated |
+| GitHub | `gist_user_session` | This cookie is used by Gist when running on a separate host. | two weeks |
+| GitHub | `has_recent_activity` | This cookie is used to prevent showing the security interstitial to users that have visited the app recently. | one hour | 
+| GitHub | `__Host-gist_user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. | two weeks | 
+| GitHub | `__Host-user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. | two weeks | 
+| GitHub | `logged_in` | This cookie is used to signal to us that the user is already logged in. | one year | 
+| GitHub | `marketplace_repository_ids` | This cookie is used for the marketplace installation flow. | one hour |
+| GitHub | `marketplace_suggested_target_id` | This cookie is used for the marketplace installation flow. | one hour |
+| GitHub | `_octo` | This cookie is used for session management including caching of dynamic content, conditional feature access, support request metadata, and first-party analytics. | one year | 
+| GitHub | `org_transform_notice` | This cookie is used to provide notice during organization transforms. | one hour |
+| GitHub | `private_mode_user_session` |  This cookie is used for Enterprise authentication requests. | two weeks |
+| GitHub | `saml_csrf_token` | This cookie is set by SAML auth path method to associate a token with the client. | until user closes browser or completes authentication request |
+| GitHub | `saml_csrf_token_legacy` | This cookie is set by SAML auth path method to associate a token with the client. | until user closes browser or completes authentication request |
+| GitHub | `saml_return_to` | This cookie is set by the SAML auth path method to maintain state during the SAML authentication loop. | until user closes browser or completes authentication request |
+| GitHub | `saml_return_to_legacy` | This cookie is set by the SAML auth path method to maintain state during the SAML authentication loop. | until user closes browser or completes authentication request |
+| GitHub | `tz` | This cookie allows us to customize timestamps to your time zone. | session | 
+| GitHub | `user_session` | This cookie is used to log you in. | two weeks |
 
-GitHub sets the following cookies on our users for the following reasons:
+_*_ The **expiration** dates for the cookies listed below generally apply on a rolling basis.
 
-| Name of Cookie | Reason |
-|---|---|
-| `user_session` | This cookie is used to log you in. |
-| `logged_in` | This cookie is used to signal to us that the user is already logged in. |
-| `dotcom_user` | This cookie is used to signal to us that the user is already logged in. |
-| `_gh_sess` | This cookie is used for temporary application and framework state between pages like what step the user is on in a multiple step form. |
-| `tz` | This cookie allows your browser to tell us what time zone you're in. |
-| `gist_user_session` | This cookie is used by Gist when running on a separate host. |
-| `saml_csrf_token` | This cookie is set by SAML auth path method to associate a token with the client. |
-| `saml_return_to` | This cookie is set by the SAML auth path method to maintain state during the SAML authentication loop. |
-| `gist_oauth_csrf` | This cookie is set by Gist to ensure the user that started the oauth flow is the same user that completes it. |
-| `__Host-user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
-| `__Host-gist_user_session_same_site` | This cookie is set to ensure that browsers that support SameSite cookies can check to see if a request originates from GitHub. |
-| `_ga` | This cookie is used by Google Analytics. |
-| `_gat` | This cookie is used by Google Analytics. |
-| `_gid` | This cookie is used by Google Analytics. |
-| `_octo` | This cookie is used by Octolytics, our internal analytics service, to distinguish unique users and clients. |
-| `tracker` | This cookie tracks the referring source for signup analytics. |
-
-Certain pages on our site may set other third party cookies. For example, we may embed content, such as videos, from another site that sets a cookie. While we try to minimize these third party cookies, we can’t always control what cookies this third party content sets.
-
-### Tracking on GitHub
-
-"[Do Not Track](https://www.eff.org/issues/do-not-track)" (DNT) is a privacy preference you can set in your browser if you do not want online services — specifically ad networks — to collect and share certain kinds of information about your online activity from third party tracking services. GitHub responds to browser DNT signals and follows the [W3C standard for responding to DNT signals](https://www.w3.org/TR/tracking-dnt/). If you would like to set your browser to signal that you would not like to be tracked, please check your browser's documentation for how to enable that signal. There are also good applications that block online tracking, such as [Privacy Badger](https://www.eff.org/privacybadger).
-
-If you have not enabled DNT on a browser that supports it, cookies on some parts of our website will track your online browsing activity on other online services over time, though we do not permit third parties other than our analytics and service providers to track GitHub users' activity over time on GitHub. We use these cookies to allow us to advertise GitHub products and services to you on third party websites and services. We also have agreements with certain vendors, such as analytics providers, who help us track visitors' movements on certain pages on our site. Only our vendors, who are collecting personal information on our behalf, may collect data on our pages, and we have signed data protection agreements with every vendor who collects this data on our behalf. We use the data we receive from these vendors to better understand our visitors' interests, to understand our website's performance, and to improve our content. Any analytics vendor will be listed in our Subprocessor List above, and you may see a list of every page where we collect this kind of data below.
-
-#### Google Analytics
-
-We use Google Analytics as a third party analytics service, and to track our advertising campaigns on third party websites and services. We use Google Analytics to collect information about how our website performs and how our users, in general, navigate through and use GitHub. This helps us evaluate our users' use of GitHub; compile statistical reports on activity; and improve our content and website performance. Google provides further information about its own privacy practices and [offers a browser add-on to opt out of Google Analytics tracking](https://tools.google.com/dlpage/gaoptout).
-
-#### Pages on GitHub where analytics may be enabled
-
-Pages at URLs that contain any of the following domains and paths (including any subdomains or subpaths) on our sites may have analytics or other tracking code enabled. If you would like to prevent us from collecting information about your browsing activity on GitHub, you may use a tracking blocker such as [Privacy Badger](https://www.eff.org/privacybadger) or opt out of Google Analytics tracking.
-
-- github.com/home (if you are logged out or do not have an account, this is the page you will see when you go to github.com)
-- github.com/about
-- github.blog
-- github.com/enterprise
-- github.com/collections
-- github.com/developer-stories
-- github.com/events
-- github.com/explore
-- github.com/features
-- github.com/logos
-- github.com/nonprofit
-- github.com/open-source
-- github.com/personal
-- github.com/pricing
-- github.com/ten
-- github.com/trending
-- resources.github.com
-- de.github.com
-- fr.github.com
+(!) Please note while we limit our use of third party cookies to those necessary to provide external functionality when rendering external content, certain pages on our website may set other third party cookies. For example, we may embed content, such as videos, from another site that sets a cookie. While we try to minimize these third party cookies, we can’t always control what cookies this third party content sets.

--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -12,7 +12,7 @@ versions:
 
 Effective date: **December 19, 2020**
 
-GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), how we use [cookies](#cookies-on-github), and where and how we perform any [tracking on GitHub](#tracking-on-github).
+GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), and how we use [cookies](#cookies-on-github).
 
 ### GitHub Subprocessors
 

--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -29,7 +29,7 @@ When we share your information with third party subprocessors, such as our vendo
 | Eloqua | Marketing campaign automation | United States | United States |
 | Google Apps | Internal company infrastructure | United States | United States |
 | Google Analytics | Analytics and performance | United States | United States |
-| LinkedIn Navigator | Marketing data enrichment service | United States | United States |
+| LinkedIn Navigator | Data enrichment service | United States | United States |
 | Magic Robot | Campaign reporting (Salesforce Add-on) | United States | United States |
 | MailChimp | Customer ticketing mail services provider | United States | United States |
 | Mailgun | Transactional mail services provider | United States | United States |
@@ -49,7 +49,7 @@ When we bring on a new subprocessor who handles our Users' Personal Information,
 
 ### Cookies on GitHub
 
-GitHub uses cookies and similar technologies (collectively, “cookies”) to provide and secure our websites, as well as to analyze the usage of our websites, in order to offer you a great user experience. Please take a look at our [Privacy Statement](/github/site-policy/github-privacy-statement#our-use-of-cookies-and-tracking) if you’d like more information about cookies, and on how and why we use them. 
+GitHub uses cookies to provide and secure our websites, as well as to analyze the usage of our websites, in order to offer you a great user experience. Please take a look at our [Privacy Statement](/github/site-policy/github-privacy-statement#our-use-of-cookies-and-tracking) if you’d like more information about cookies, and on how and why we use them. 
  
 Since the number and names of cookies may change,the table below may be updated from time to time.
 
@@ -68,7 +68,7 @@ Since the number and names of cookies may change,the table below may be updated 
 | GitHub | `logged_in` | This cookie is used to signal to us that the user is already logged in. | one year | 
 | GitHub | `marketplace_repository_ids` | This cookie is used for the marketplace installation flow. | one hour |
 | GitHub | `marketplace_suggested_target_id` | This cookie is used for the marketplace installation flow. | one hour |
-| GitHub | `_octo` | This cookie is used for session management including caching of dynamic content, conditional feature access, support request metadata, and first-party analytics. | one year | 
+| GitHub | `_octo` | This cookie is used for session management including caching of dynamic content, conditional feature access, support request metadata, and first party analytics. | one year | 
 | GitHub | `org_transform_notice` | This cookie is used to provide notice during organization transforms. | one hour |
 | GitHub | `private_mode_user_session` |  This cookie is used for Enterprise authentication requests. | two weeks |
 | GitHub | `saml_csrf_token` | This cookie is set by SAML auth path method to associate a token with the client. | until user closes browser or completes authentication request |


### PR DESCRIPTION
Updates cookie language to reflect the removal of non-essential cookies.

These material changes will go into effect after the 30-day notice and comment period, on December 19, at 5PM PT.