### PR TITLE
Move Pages "prohibited uses" from documentation to terms

### DIFF
--- a/Policies/github-additional-product-terms.md
+++ b/Policies/github-additional-product-terms.md
@@ -4,7 +4,7 @@ versions:
   free-pro-team: '*'
 ---
 
-Version Effective Date: December 14, 2020
+Version Effective Date: February 22, 2021
 
 When you create an Account, you're given access to lots of different features and products that are all a part of the Service. Because many of these features and products offer different functionality, they may require additional terms and conditions specific to that feature or product. Below, we've listed those features and products, along with the corresponding additional terms that apply to your use of them.
 
@@ -39,9 +39,24 @@ If you enable Git Large File Storage ("Git LFS") on your Account, you'll be able
 
 ### 4. Pages
 
-Each Account comes with access to the [GitHub Pages static hosting service](/github/working-with-github-pages/about-github-pages). This hosting service is intended to host static web pages for All Users, but primarily as a showcase for personal and organizational projects. Some monetization efforts are permitted on Pages, such as donation buttons and crowdfunding links.
+Each Account comes with access to the [GitHub Pages static hosting service](/github/working-with-github-pages/about-github-pages). This hosting service is intended to host static web pages for All Users, but primarily as a showcase for personal and organizational projects. 
 
-GitHub Pages are subject to some specific bandwidth and usage limits, and may not be appropriate for some high-bandwidth uses or other prohibited uses. Please see our [GitHub Pages guidelines](/github/working-with-github-pages/about-github-pages) for more information. GitHub reserves the right at all times to reclaim any GitHub subdomain without liability.
+GitHub Pages is not intended for or allowed to be used as a free web hosting service to run your online business, e-commerce site, or any other website that is primarily directed at either facilitating commercial transactions or providing commercial software as a service (SaaS). Some monetization efforts are permitted on Pages, such as donation buttons and crowdfunding links. 
+
+#### a. Bandwidth and Usage Limits
+GitHub Pages are subject to some specific bandwidth and usage limits, and may not be appropriate for some high-bandwidth uses. Please see our [GitHub Pages guidelines](/github/working-with-github-pages/about-github-pages) for more information. 
+
+#### b. Prohibited Uses
+Prohibited uses of GitHub Pages include
+- Content or activity that is illegal or otherwise prohibited by our [Terms of Service](/github/site-policy/github-terms-of-service), [Acceptable Use Policies](/github/site-policy/github-acceptable-use-policies) or [Community Guidelines](/github/site-policy/github-community-guidelines)
+- Violent or threatening content or activity
+- Excessive automated bulk activity (for example, spamming)
+- Activity that compromises GitHub users or GitHub services
+- Get-rich-quick schemes
+- Sexually obscene content
+- Content that misrepresents your identity or site purpose
+
+If you have questions about whether your use or intended use falls into these categories, please contact [GitHub Support](https://support.github.com/contact) or [GitHub Premium Support](https://premium.githubsupport.com/). GitHub reserves the right at all times to reclaim any GitHub subdomain without liability.
 
 ### 5. Actions and Packages
 


### PR DESCRIPTION
This PR moves section on `prohibited uses` from [Pages documentation](https://docs.github.com/en/github/working-with-github-pages/about-github-pages#prohibited-uses) to the [Pages section](https://docs.github.com/en/github/site-policy/github-additional-product-terms#4-pages) of our Additional Product Terms

(There's no change in content - just moving words around.)

We plan to merge this PR on Monday, Feb. 22.