### PR TITLE
Updates to our repo sync 

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -1,0 +1,14 @@
+name: autoupdate
+on:
+  push:
+     branches:
+       - main
+
+jobs:
+  autoupdate:
+    name: autoupdate
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:bd5708a4e03a2e30139fae713378946bf0f40ab8
+        env:
+          GITHUB_TOKEN: '${{ secrets.API_TOKEN_SITEPOLICY }}'

--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -14,12 +14,12 @@ jobs:
     name: PullRequestAction
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.3
+        uses: vsoch/pull-request-action@1cb1956a68e7d8b6bf693d41299467bb0f1b6a7a
         env:
           GITHUB_TOKEN: ${{ secrets.API_TOKEN_SITEPOLICY }}
           PULL_REQUEST_BRANCH: "main"
-          PULL_REQUEST_BODY: "Automatic sync with changes from GitHub Docs"
+          PULL_REQUEST_BODY: "Automatic sync with changes from GitHub Docs. Details provided in commit titles below:"
           PULL_REQUEST_ASSIGNEES: "@pcihon"  


### PR DESCRIPTION
These changes will improve our automated sync from GitHub Docs as minor changes are made there, to ensure that the site policies listed here reflect our up-to-date versions posted publicly on our website at docs.github.com
