### PR TITLE
add link to Developer Defense Fund in DMCA policy

### DIFF
--- a/Policies/dmca-takedown-policy.md
+++ b/Policies/dmca-takedown-policy.md
@@ -85,7 +85,7 @@ Where our experts determine that a claim is complete, legal, and technically leg
 
 Please note, our review process for circumvention technology does not apply to content that would otherwise violate our Acceptable Use Policy restrictions against sharing unauthorized product licensing keys, software for generating unauthorized product licensing keys, or software for bypassing checks for product licensing keys. Although these types of claims may also violate the DMCA provisions on circumvention technology, these are typically straightforward and do not warrant additional technical and legal review. Nonetheless, where a claim is not straightforward, for example in the case of jailbreaks, the circumvention technology claim review process would apply.  
 
-When GitHub processes a DMCA takedown under our circumvention technology claim review process, we will offer to connect the repository owner with legal resources, in case the repository owner wishes to obtain third party legal advice.
+When GitHub processes a DMCA takedown under our circumvention technology claim review process, we will offer to connect the repository owner with legal resources through [GitHub’s Developer Defense Fund](https://github.blog/2021-07-27-github-developer-rights-fellowship-stanford-law-school/) in case the repository owner wishes to obtain third party legal advice.
 
 ## D. What If I Inadvertently Missed the Window to Make Changes?
 


### PR DESCRIPTION
adds link to Developer Defense Fund https://github.blog/2021-07-27-github-developer-rights-fellowship-stanford-law-school/ in DMCA policy