### PR TITLE
Added Note to Cookies page about pending changes

### DIFF
--- a/Policies/github-subprocessors-and-cookies.md
+++ b/Policies/github-subprocessors-and-cookies.md
@@ -15,6 +15,12 @@ topics:
 
 Effective date: **April 2, 2021**
 
+{% note %}
+
+**Note:** Changes to the list of cookies on this page are currently pending.
+
+{% endnote %}
+
 GitHub provides a great deal of transparency regarding how we use your data, how we collect your data, and with whom we share your data. To that end, we provide this page, which details [our subprocessors](#github-subprocessors), and how we use [cookies](#cookies-on-github).
 
 ## GitHub Subprocessors


### PR DESCRIPTION
This change notifies users that the cookie list will be updated on GitHub Subprocessors and Cookies page.