### PR TITLE
Update github-username-policy.md

### DIFF
--- a/Policies/github-username-policy.md
+++ b/Policies/github-username-policy.md
@@ -20,7 +20,7 @@ If the username you want has already been claimed, consider other names or uniqu
 
 ## Trademark Policy
 
-If you believe someone's account is violating your trademark rights, you can find more information about making a trademark complaint on our [Trademark Policy](/articles/github-trademark-policy/) page.
+If you believe someone's account is violating your trademark rights, you can find more information about making a trademark complaint on our [Trademark Policy](https://docs.github.com/en/site-policy/content-removal-policies/github-trademark-policy) page.
 
 ## Name Squatting Policy
 


### PR DESCRIPTION
The link to the Trademark Policy documents was invalid and I replaced this link with https://docs.github.com/en/site-policy/content-removal-policies/github-trademark-policy and it goes directly to GitHub Trademark Policy