### PR TITLE
Introduce the GitHub Account Recovery Policy

### DIFF
--- a/Policies/other-site-policies/github-account-recovery-policy.md
+++ b/Policies/other-site-policies/github-account-recovery-policy.md
@@ -1,0 +1,35 @@
+---
+title: GitHub Account Recovery Policy
+versions:
+  fpt: '*'
+topics:
+  - 2FA
+  - Policy
+  - Legal
+---
+
+GitHub provides [a number of account recovery methods](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials) including an [automated recovery process](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials#authenticating-with-a-verified-device-ssh-token-or-personal-access-token) if you have lost access to your GitHub.com account. **If you cannot use any of the provided recovery methods, you have permanently lost access to your account.**  
+
+You can, however, [unlink email addresses](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/unlinking-your-email-address-from-a-locked-account) from a locked account in order to create a new account or use the email on another existing account.
+
+## Can I open a support ticket to recover my account?
+
+For security reasons, **GitHub Support will not restore access to accounts with two-factor authentication enabled if you lose your two-factor authentication credentials or lose access to your account recovery methods.** You must use existing [account recovery methods](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials).
+
+GitHub does not support any other means of account recovery, including social or ID verification, by members of GitHub’s staff. This policy is in place to protect your account from unauthorized access through social engineering.
+
+## How can I retrieve my email from a locked account?
+
+See [Unlinking your email address from a locked account](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/unlinking-your-email-address-from-a-locked-account).
+
+## How can I remove a payment method from a locked account?
+
+Please contact Support to request removal of a payment method from a locked out account. Remember, **GitHub Support will not restore your account** if you lose access to your account recovery methods.
+
+## Can I recover the contents of a user or organization account I lost access to?
+
+If you have lost access to a user account, you may [clone](/repositories/creating-and-managing-repositories/cloning-a-repository) or [fork](/get-started/quickstart/fork-a-repo) any content that is public.
+
+If you have lost access to an organization account, you may clone or fork any content that is public and you may be able to request that remaining members of the organization clone or fork any private content.
+
+GitHub Support will not recover the contents of a user or organization account that is locked.


### PR DESCRIPTION
# Thank you for your interest in improving GitHub's site policies!
![new](https://img.shields.io/badge/-new!-yellow) Please follow this workflow to have your edits considered:
1. Open a pull request directly in the [GitHub Docs](https://github.com/github/docs) repo.
- This PR has been opened per internal documentation practices.  See: https://github.com/github/docs-internal/pull/36950
3. Open [an issue in this site-policy repo](https://github.com/github/site-policy/issues/new) describing your change and link it to your PR.
- https://github.com/github/site-policy/issues/759
5. We will then consider your change and get back to you. Thank you!

### Context
This policy is being documented to codify and formalize existing practices regarding how GitHub handles account lockout recovery and to make clear that GitHub Support will not unlock accounts if the user has lost access to all approved means of account recovery.  This policy makes clear GitHub's practices, established to protect users from social engineering and account theft.

This PR will remain open for feedback for a minimum of 24 hours as it does not introduce material changes to policy and simply codifies existing practice.
