### PR TITLE
Update github-account-recovery-policy.md

### DIFF
--- a/Policies/other-site-policies/github-account-recovery-policy.md
+++ b/Policies/other-site-policies/github-account-recovery-policy.md
@@ -14,7 +14,7 @@ You can, however, [unlink email addresses](/account-and-profile/setting-up-and-m
 
 ## Can I open a support ticket to recover my account?
 
-For security reasons, **GitHub Support will not restore access to accounts with two-factor authentication enabled if you lose your two-factor authentication credentials or lose access to your account recovery methods.** You must use existing [account recovery methods](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials).
+For security reasons, **GitHub Support will not restore access to accounts with two-factor authentication enabled if you lose your two-factor authentication credentials or lose access to your account recovery methods. Note that if you have access to two-factor authentication, and even if you have access to github account recovery codes, you can not recover your account if you forget your password.** You must use existing [account recovery methods](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials).
 
 GitHub does not support any other means of account recovery, including social or ID verification, by members of GitHub’s staff. This policy is in place to protect your account from unauthorized access through social engineering.
 


### PR DESCRIPTION
# Thank you for your interest in improving GitHub's site policies!
![new](https://img.shields.io/badge/-new!-yellow) Please follow this workflow to have your edits considered:
1. Open a pull request directly in the [GitHub Docs](https://github.com/github/docs) repo.
2. Open [an issue in this site-policy repo](https://github.com/github/site-policy/issues/new) describing your change and link it to your PR.
3. We will then consider your change and get back to you. Thank you!

### Context

This policy makes it clear that GitHub Support will not unlock accounts if the user has forgotten the account password, even if the user has access to two-factor authentication (2FA) and github recovery codes.

Fixes https://github.com/github/site-policy/issues/1048


