### PR TITLE
Update GitHub Sponsors Additional Terms to clarify Stripe's payment processing role

### DIFF
--- a/Policies/github-terms/github-sponsors-additional-terms.md
+++ b/Policies/github-terms/github-sponsors-additional-terms.md
@@ -373,8 +373,15 @@ To the maximum extent permitted by applicable law, in no event will either party
 
 ## A. Confidentiality.
 
-The terms and conditions of this Agreement are the Confidential Information of both parties. Neither party will use Confidential Information provided by the other party hereunder, except as permitted by this Agreement.
+The terms and conditions of this Agreement are the Confidential Information of both parties. In addition, any non-public information disclosed by one party to the other in connection with the Program that is designated as confidential or that, given the nature of the information or the circumstances surrounding its disclosure, reasonably should be understood to be confidential, will be considered "Confidential Information" of the disclosing party.
 
+Neither party will use Confidential Information provided by the other party hereunder, except to exercise its rights and perform its obligations under this Agreement or as otherwise permitted by this Agreement. Each party will protect the other party's Confidential Information from unauthorized use, access, or disclosure using at least the degree of care it uses to protect its own similar information, and in any event no less than a reasonable degree of care.
+
+Each party may disclose the other party's Confidential Information only to its and its Affiliates' employees, contractors, and professional advisors who have a legitimate need to know the Confidential Information for purposes consistent with this Agreement and who are bound by confidentiality obligations at least as protective as those set forth in this Agreement. The receiving party will be responsible for any breach of this Section A by its Affiliates, employees, contractors, or professional advisors.
+
+The obligations in this Section A will not apply to any information that: (a) is or becomes generally known to the public through no fault of the receiving party; (b) was known to the receiving party without restriction before receipt from the disclosing party; (c) is independently developed by the receiving party without use of or reference to the disclosing party's Confidential Information; or (d) is rightfully received by the receiving party from a third party without a duty of confidentiality.
+
+A receiving party may disclose the disclosing party's Confidential Information to the extent required by law, regulation, or a valid order of a court or other governmental authority, provided that (where legally permitted) the receiving party gives the disclosing party prompt written notice of the requirement and cooperates, at the disclosing party's expense, in seeking a protective order or other appropriate remedy.
 ## B. Publicity.
 
 GitHub may issue press releases, blog posts, social media posts, and/or other public communication related to Sponsor's (with Sponsor's permission) or Sponsored Developer's participation in the Program. Other than as necessary for such use, GitHub shall acquire no rights to use or refer to, or interest in, such Sponsor's logo, name or names under this Agreement.


### PR DESCRIPTION
## Summary

This PR updates the GitHub Sponsors Additional Terms to clarify that Stripe is the sole payment processor and that GitHub acts only as a technical platform.

## Key Changes

### New Sections
- **Section 1A (Payment Processing by Stripe)**: Defines Stripe as the sole payment processor, establishes the direct Stripe-developer relationship, and clarifies GitHub's limited role
- **Section 3.9 (No GitHub Liability for Payment Processing)**: Explicit disclaimer of GitHub's liability for Stripe's payment processing
- **Section 4.1A (Payment Processing Disclaimer)**: Additional disclaimer for Sponsors regarding payment processing
- **Pooled Funds provision** (in Section 3.3): New payment timing rules for SOSS Fund or similar pooled funding mechanisms

### Updated Sections
- **Definitions**: Updated to third-person references and added Stripe references (Sponsored Developer Account now defined as account at Stripe; Sponsorship paid through Program and Stripe)
- **Section 3.1 (Payment)**: Rewritten to clarify all payments processed by Stripe, not GitHub
- **Section 3.2.3 (Withholding for Breach)**: Added Sponsor reallocation rights
- **Section 3.3 (Payment Timing)**: Updated to reference Stripe as the entity processing/remitting payments
- **Section 2.1 (Sponsor Payment)**: Rewritten to clarify funds are held by Stripe
- **Section 3.7**: Updated from "To pay you" to "To receive Sponsored Developer Payments"

### Removed Sections
- **Matching Fund detailed terms** (Sections 1.2.1, 1.2.2)
- **Registration** (Section 2.2)
- **Content Monetization** including Subscriptions, Other Sponsorships, and Advertising (Section 2.3)
- **ACH/wire transfer payment option** (consolidated to Stripe Connect only)
- **Payment Method** (Section 3.4) and **Refund Requirements** (Section 3.6)
- **Stripe Recipient service agreement** (for non-listed countries)
- **Representations and Warranties; Limitation of Liability; Indemnification** (Section 4)
- **Term and Termination** for Sponsored Developers (Section 5)
- **Sponsors subsections**: Invoice creation, Dashboard, Feedback (Sections 1.2-1.4)
- **General Program Terms**: Publicity (B), Notices (C), Assignment (E), Severability (F)